### PR TITLE
[codex] Bench air first-build reference stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: rhi-demo rhi-validate rhi-check
+.PHONY: rhi-demo rhi-validate rhi-check rhi-http-check
 
 rhi-demo:
 	python3 programs/resilient-home-intelligence/software/parcel-platform/scripts/reference_pipeline.py
@@ -8,3 +8,6 @@ rhi-validate:
 
 rhi-check:
 	./scripts/rhi_smoke_check.sh
+
+rhi-http-check:
+	./scripts/rhi_http_smoke_check.sh

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/README.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/README.md
@@ -87,4 +87,5 @@ See `open-questions.md` for unresolved decisions on enclosure, long-term drift h
 - `wiring.md`
 - `firmware-notes.md`
 - `serial-json-contract.md`
+- `operator-runbook.md`
 - `firmware/README.md`

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/build-guide.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/build-guide.md
@@ -113,5 +113,6 @@ This version is for indoor or sheltered testing only. If it is used on a porch o
 - `wiring.md`
 - `firmware-notes.md`
 - `serial-json-contract.md`
+- `operator-runbook.md`
 - `firmware/README.md`
 - `calibration.md`

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/.gitignore
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/.gitignore
@@ -1,0 +1,3 @@
+.pio/
+.vscode/
+bench_air_node_serial_json/secrets.h

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
@@ -10,6 +10,27 @@ Provide a minimal ESP32 bring-up sketch that emits the agreed `rhi.bench-air.v1`
   Minimal I2C scanner for `GPIO8` and `GPIO9`
 - `bench_air_node_serial_json/bench_air_node_serial_json.ino`
   Arduino-style sketch for ESP32-S3 that reads SHT45 and BME680, then prints one JSON packet per line at `115200`
+- `bench_air_node_serial_json/secrets.example.h`
+  Copy-to-local template for optional Wi-Fi time-sync credentials
+- `platformio.ini`
+  Pinned ESP32-S3 build scaffold with separate environments for the scanner and serial JSON sketch
+- `tools/capture_serial.sh`
+  Simple macOS serial capture helper that writes a monitor log to disk
+
+## Pinned build setup
+
+The firmware directory now includes `platformio.ini` with a pinned ESP32 platform and library set:
+
+- platform: `espressif32@6.7.0`
+- board: `esp32-s3-devkitc-1`
+- framework: Arduino
+
+Recommended commands from this directory:
+
+```bash
+pio run -e bench_air_node_i2c_scanner
+pio run -e bench_air_node_serial_json
+```
 
 ## Arduino libraries
 
@@ -26,7 +47,13 @@ The serial JSON sketch can emit a real UTC `observed_at` timestamp if you fill i
 - `kWifiSsid`
 - `kWifiPassword`
 
-If those remain blank, the sketch stays in serial-only bring-up mode and uses the placeholder timestamp.
+Recommended local pattern:
+
+1. Copy `bench_air_node_serial_json/secrets.example.h` to `bench_air_node_serial_json/secrets.h`
+2. Fill in your Wi-Fi credentials locally
+3. Do not commit `secrets.h`
+
+If credentials remain blank, the sketch stays in serial-only bring-up mode and uses the placeholder timestamp.
 
 ## First run
 
@@ -40,6 +67,20 @@ If those remain blank, the sketch stays in serial-only bring-up mode and uses th
 8. Flash the serial JSON sketch
 9. Confirm you see one valid JSON object per line every 5 seconds
 10. If Wi-Fi credentials are configured, confirm you see a `# time synced:` boot line and non-placeholder `observed_at` values
+
+## Serial capture on macOS
+
+To save a serial session to `serial.log`, first identify the device:
+
+```bash
+ls /dev/cu.usbmodem*
+```
+
+Then run:
+
+```bash
+./tools/capture_serial.sh /dev/cu.usbmodem101 serial.log
+```
 
 ## Current limitations
 

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
@@ -37,3 +37,5 @@ Install these libraries before compiling the serial JSON sketch:
 - Wi-Fi transport is not enabled
 
 The immediate goal is to prove sensor bring-up, packet shape, and ingest compatibility first. Time sync and network transport can come next.
+
+For the full bench workflow from flash to local ingest validation, use `../operator-runbook.md`.

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/README.md
@@ -19,6 +19,15 @@ Install these libraries before compiling the serial JSON sketch:
 - `Adafruit BME680 Library`
 - `Adafruit Unified Sensor`
 
+## Optional time sync
+
+The serial JSON sketch can emit a real UTC `observed_at` timestamp if you fill in:
+
+- `kWifiSsid`
+- `kWifiPassword`
+
+If those remain blank, the sketch stays in serial-only bring-up mode and uses the placeholder timestamp.
+
 ## First run
 
 1. Open `bench_air_node_i2c_scanner.ino` in the Arduino IDE or another ESP32-capable workflow
@@ -30,10 +39,11 @@ Install these libraries before compiling the serial JSON sketch:
 7. Open `bench_air_node_serial_json.ino`
 8. Flash the serial JSON sketch
 9. Confirm you see one valid JSON object per line every 5 seconds
+10. If Wi-Fi credentials are configured, confirm you see a `# time synced:` boot line and non-placeholder `observed_at` values
 
 ## Current limitations
 
-- `observed_at` is still a placeholder timestamp until real time is available
+- `observed_at` remains a placeholder unless Wi-Fi time sync is configured and succeeds
 - Wi-Fi transport is not enabled
 
 The immediate goal is to prove sensor bring-up, packet shape, and ingest compatibility first. Time sync and network transport can come next.

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_i2c_scanner/bench_air_node_i2c_scanner.ino
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_i2c_scanner/bench_air_node_i2c_scanner.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <Wire.h>
 
 static const int kI2cSdaPin = 8;

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
@@ -9,13 +9,25 @@
 #include <Adafruit_SHT4x.h>
 #include <Adafruit_Sensor.h>
 
+#if __has_include("secrets.h")
+#include "secrets.h"
+#endif
+
+#ifndef BENCH_AIR_WIFI_SSID
+#define BENCH_AIR_WIFI_SSID ""
+#endif
+
+#ifndef BENCH_AIR_WIFI_PASSWORD
+#define BENCH_AIR_WIFI_PASSWORD ""
+#endif
+
 static const char* kSchemaVersion = "rhi.bench-air.v1";
 static const char* kNodeId = "bench-air-01";
 static const char* kFirmwareVersion = "0.1.0";
 static const char* kLocationMode = "indoor";
 static const char* kObservedAtPlaceholder = "1970-01-01T00:00:00Z";
-static const char* kWifiSsid = "";
-static const char* kWifiPassword = "";
+static const char* kWifiSsid = BENCH_AIR_WIFI_SSID;
+static const char* kWifiPassword = BENCH_AIR_WIFI_PASSWORD;
 static const char* kNtpServer = "pool.ntp.org";
 static const long kGmtOffsetSeconds = 0;
 static const int kDaylightOffsetSeconds = 0;

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
@@ -2,12 +2,19 @@
 // Uses SHT45 and BME680 over I2C on GPIO8/GPIO9 and prints one
 // JSON packet per line for local ingest validation.
 
+#include <Arduino.h>
 #include <Wire.h>
-#include <WiFi.h>
 #include <time.h>
 #include <Adafruit_BME680.h>
 #include <Adafruit_SHT4x.h>
 #include <Adafruit_Sensor.h>
+
+#if __has_include(<WiFi.h>)
+#include <WiFi.h>
+#define BENCH_AIR_HAS_WIFI 1
+#else
+#define BENCH_AIR_HAS_WIFI 0
+#endif
 
 #if __has_include("secrets.h")
 #include "secrets.h"
@@ -230,6 +237,13 @@ void syncTimeIfConfigured() {
     return;
   }
 
+#if !BENCH_AIR_HAS_WIFI
+  last_error = "wifi_unavailable";
+  Serial.println("# Wi-Fi support unavailable in this build, using placeholder observed_at");
+  wifi_connected = false;
+  time_synced = false;
+  return;
+#else
   WiFi.mode(WIFI_STA);
   WiFi.begin(kWifiSsid, kWifiPassword);
 
@@ -267,6 +281,7 @@ void syncTimeIfConfigured() {
   updateObservedAt();
   Serial.print("# time synced: ");
   Serial.println(observed_at);
+#endif
 }
 
 void setup() {

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino
@@ -3,6 +3,8 @@
 // JSON packet per line for local ingest validation.
 
 #include <Wire.h>
+#include <WiFi.h>
+#include <time.h>
 #include <Adafruit_BME680.h>
 #include <Adafruit_SHT4x.h>
 #include <Adafruit_Sensor.h>
@@ -12,10 +14,17 @@ static const char* kNodeId = "bench-air-01";
 static const char* kFirmwareVersion = "0.1.0";
 static const char* kLocationMode = "indoor";
 static const char* kObservedAtPlaceholder = "1970-01-01T00:00:00Z";
+static const char* kWifiSsid = "";
+static const char* kWifiPassword = "";
+static const char* kNtpServer = "pool.ntp.org";
+static const long kGmtOffsetSeconds = 0;
+static const int kDaylightOffsetSeconds = 0;
 
 static const int kI2cSdaPin = 8;
 static const int kI2cSclPin = 9;
 static const unsigned long kSampleIntervalMs = 5000;
+static const unsigned long kWifiConnectTimeoutMs = 15000;
+static const unsigned long kTimeSyncTimeoutMs = 15000;
 static const uint8_t kBme680Addresses[] = {0x77, 0x76};
 
 struct Sht45Reading {
@@ -38,6 +47,9 @@ bool sht45_present = false;
 bool bme680_present = false;
 uint8_t bme680_address = 0;
 String last_error = "boot";
+bool wifi_connected = false;
+bool time_synced = false;
+String observed_at = kObservedAtPlaceholder;
 
 Adafruit_SHT4x sht4 = Adafruit_SHT4x();
 Adafruit_BME680 bme680;
@@ -108,13 +120,32 @@ void printJsonString(const String& value) {
   Serial.print('"');
 }
 
+void updateObservedAt() {
+  if (!time_synced) {
+    observed_at = kObservedAtPlaceholder;
+    return;
+  }
+
+  struct tm time_info;
+  if (!getLocalTime(&time_info)) {
+    observed_at = kObservedAtPlaceholder;
+    time_synced = false;
+    last_error = "time_read_failed";
+    return;
+  }
+
+  char buffer[25];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &time_info);
+  observed_at = buffer;
+}
+
 void emitPacket(const Sht45Reading& sht45, const Bme680Reading& bme680) {
   Serial.print("{\"schema_version\":\"");
   Serial.print(kSchemaVersion);
   Serial.print("\",\"node_id\":\"");
   Serial.print(kNodeId);
   Serial.print("\",\"observed_at\":\"");
-  Serial.print(kObservedAtPlaceholder);
+  Serial.print(observed_at);
   Serial.print("\",\"firmware_version\":\"");
   Serial.print(kFirmwareVersion);
   Serial.print("\",\"location_mode\":\"");
@@ -143,7 +174,9 @@ void emitPacket(const Sht45Reading& sht45, const Bme680Reading& bme680) {
   printFloat(bme680.pressure_hpa);
   Serial.print(",\"voc_trend_source\":\"gas_resistance_ohm\"},\"health\":{\"uptime_s\":");
   Serial.print(millis() / 1000UL);
-  Serial.print(",\"wifi_connected\":false,\"free_heap_bytes\":");
+  Serial.print(",\"wifi_connected\":");
+  Serial.print(wifi_connected ? "true" : "false");
+  Serial.print(",\"free_heap_bytes\":");
 #ifdef ESP32
   Serial.print(ESP.getFreeHeap());
 #else
@@ -177,6 +210,53 @@ bool beginBme680() {
   return false;
 }
 
+void syncTimeIfConfigured() {
+  if (strlen(kWifiSsid) == 0) {
+    Serial.println("# Wi-Fi not configured, using placeholder observed_at");
+    wifi_connected = false;
+    time_synced = false;
+    return;
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(kWifiSsid, kWifiPassword);
+
+  unsigned long wifi_start_ms = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - wifi_start_ms < kWifiConnectTimeoutMs) {
+    delay(250);
+  }
+
+  wifi_connected = WiFi.status() == WL_CONNECTED;
+  if (!wifi_connected) {
+    last_error = "wifi_connect_failed";
+    Serial.println("# Wi-Fi connect failed, using placeholder observed_at");
+    return;
+  }
+
+  Serial.print("# Wi-Fi connected, IP=");
+  Serial.println(WiFi.localIP());
+
+  configTime(kGmtOffsetSeconds, kDaylightOffsetSeconds, kNtpServer);
+  unsigned long time_start_ms = millis();
+  while (!time_synced && millis() - time_start_ms < kTimeSyncTimeoutMs) {
+    struct tm time_info;
+    if (getLocalTime(&time_info, 250)) {
+      time_synced = true;
+      break;
+    }
+  }
+
+  if (!time_synced) {
+    last_error = "ntp_sync_failed";
+    Serial.println("# NTP sync failed, using placeholder observed_at");
+    return;
+  }
+
+  updateObservedAt();
+  Serial.print("# time synced: ");
+  Serial.println(observed_at);
+}
+
 void setup() {
   Serial.begin(115200);
   delay(250);
@@ -188,6 +268,7 @@ void setup() {
   Serial.print(" SCL=GPIO");
   Serial.println(kI2cSclPin);
   Serial.println("# using Adafruit SHT4x and BME680 libraries");
+  syncTimeIfConfigured();
 
   sht45_present = sht4.begin(&Wire);
   if (sht45_present) {
@@ -228,6 +309,7 @@ void loop() {
 
   Sht45Reading sht45 = readSht45();
   Bme680Reading bme680 = readBme680();
+  updateObservedAt();
 
   if (!sht45.present || !bme680.present) {
     read_failures_total++;

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/secrets.example.h
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/bench_air_node_serial_json/secrets.example.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Copy this file to secrets.h and fill in your local Wi-Fi credentials
+// if you want NTP-backed observed_at timestamps during bench bring-up.
+
+#define BENCH_AIR_WIFI_SSID ""
+#define BENCH_AIR_WIFI_PASSWORD ""

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/platformio.ini
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-src_dir = .
+src_dir = src
 default_envs = bench_air_node_i2c_scanner
 
 [env]
@@ -15,9 +15,9 @@ lib_deps =
 [env:bench_air_node_i2c_scanner]
 build_src_filter =
   -<*>
-  +<bench_air_node_i2c_scanner/>
+  +<bench_air_node_i2c_scanner.cpp>
 
 [env:bench_air_node_serial_json]
 build_src_filter =
   -<*>
-  +<bench_air_node_serial_json/>
+  +<bench_air_node_serial_json.cpp>

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/platformio.ini
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/platformio.ini
@@ -1,0 +1,23 @@
+[platformio]
+src_dir = .
+default_envs = bench_air_node_i2c_scanner
+
+[env]
+platform = espressif32@6.7.0
+framework = arduino
+board = esp32-s3-devkitc-1
+monitor_speed = 115200
+lib_deps =
+  adafruit/Adafruit SHT4x Library@^1.0.5
+  adafruit/Adafruit BME680 Library@^2.0.5
+  adafruit/Adafruit Unified Sensor@^1.1.14
+
+[env:bench_air_node_i2c_scanner]
+build_src_filter =
+  -<*>
+  +<bench_air_node_i2c_scanner/>
+
+[env:bench_air_node_serial_json]
+build_src_filter =
+  -<*>
+  +<bench_air_node_serial_json/>

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/src/bench_air_node_i2c_scanner.cpp
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/src/bench_air_node_i2c_scanner.cpp
@@ -1,0 +1,1 @@
+#include "../bench_air_node_i2c_scanner/bench_air_node_i2c_scanner.ino"

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/src/bench_air_node_serial_json.cpp
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/src/bench_air_node_serial_json.cpp
@@ -1,0 +1,1 @@
+#include "../bench_air_node_serial_json/bench_air_node_serial_json.ino"

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/tools/capture_serial.sh
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/firmware/tools/capture_serial.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <serial-device> [output-log]"
+  echo "Example: $0 /dev/cu.usbmodem101 serial.log"
+  exit 1
+fi
+
+device="$1"
+output="${2:-serial.log}"
+
+stty -f "$device" 115200 cs8 -cstopb -parenb -ixon -ixoff -crtscts
+
+echo "Capturing serial output from $device to $output"
+echo "Press Ctrl-C to stop."
+
+cat "$device" | tee "$output"

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
@@ -63,7 +63,8 @@ Stop here if the second address does not appear.
 
 Optional before flashing:
 
-- fill in `kWifiSsid` and `kWifiPassword` in the sketch if you want real UTC timestamps via NTP
+- copy `firmware/bench_air_node_serial_json/secrets.example.h` to `firmware/bench_air_node_serial_json/secrets.h`
+- fill in your Wi-Fi credentials there if you want real UTC timestamps via NTP
 
 Expected boot comments:
 
@@ -98,6 +99,13 @@ If you captured a whole serial monitor log with `#` boot lines, extract the newe
 ```bash
 python3 scripts/extract_latest_packet.py serial.log --output packet.json
 python3 scripts/ingest_packet.py packet.json
+```
+
+Recommended macOS capture flow:
+
+```bash
+cd ../../hardware/bench-air-node/firmware
+./tools/capture_serial.sh /dev/cu.usbmodem101 serial.log
 ```
 
 ## Pass criteria

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
@@ -61,6 +61,10 @@ Stop here if the second address does not appear.
 3. Ignore the boot comment lines that start with `#`
 4. Copy one full JSON packet line into a file named `packet.json`
 
+Optional before flashing:
+
+- fill in `kWifiSsid` and `kWifiPassword` in the sketch if you want real UTC timestamps via NTP
+
 Expected boot comments:
 
 ```text
@@ -73,6 +77,7 @@ Expected packet behavior:
 - one JSON object per line
 - one packet about every 5 seconds
 - `sht45` and `bme680` both present when wiring is healthy
+- `observed_at` is a real UTC timestamp only if Wi-Fi time sync is configured and succeeds
 
 ## Stage 4: validate locally
 
@@ -98,8 +103,8 @@ python3 scripts/ingest_packet.py < packet.json
 
 ## Known first-build limitations
 
-- `observed_at` is still a placeholder timestamp until time sync is added
-- `wifi_connected` remains `false`
+- `observed_at` remains a placeholder if Wi-Fi time sync is not configured or fails
+- Wi-Fi is only used here for optional time sync, not packet transport
 - gas resistance is useful for trend inspection, not calibrated AQI
 
 ## If something fails

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
@@ -1,0 +1,110 @@
+# Operator Runbook
+
+## Purpose
+
+Provide the shortest repeatable path from freshly wired bench hardware to a locally validated normalized observation.
+
+## Before you start
+
+- ESP32-S3 DevKitC-1 wired with `GPIO8` as `SDA` and `GPIO9` as `SCL`
+- SHT45 connected first
+- BME680 ready to add after the first scan passes
+- Arduino IDE or equivalent ESP32 workflow installed
+- local repo available so `python3 scripts/ingest_packet.py` can be run
+
+## Arduino libraries
+
+Install these libraries before flashing the serial JSON sketch:
+
+- `Adafruit SHT4x Library`
+- `Adafruit BME680 Library`
+- `Adafruit Unified Sensor`
+
+## Stage 1: scan SHT45 only
+
+1. Flash `firmware/bench_air_node_i2c_scanner/bench_air_node_i2c_scanner.ino`
+2. Open the serial monitor at `115200`
+3. Confirm you see `Found device at 0x44`
+
+Expected output shape:
+
+```text
+I2C scan starting...
+Found device at 0x44
+Total devices found: 1
+```
+
+Stop here if `0x44` does not appear.
+
+## Stage 2: add BME680 and scan again
+
+1. Power off the board
+2. Add the BME680 to the same `3V3`, `GND`, `SDA`, and `SCL` bus
+3. Power back on with the same scanner sketch
+4. Confirm you see `0x44` plus `0x76` or `0x77`
+
+Expected output shape:
+
+```text
+I2C scan starting...
+Found device at 0x44
+Found device at 0x77
+Total devices found: 2
+```
+
+Stop here if the second address does not appear.
+
+## Stage 3: flash serial JSON sketch
+
+1. Flash `firmware/bench_air_node_serial_json/bench_air_node_serial_json.ino`
+2. Open the serial monitor at `115200`
+3. Ignore the boot comment lines that start with `#`
+4. Copy one full JSON packet line into a file named `packet.json`
+
+Expected boot comments:
+
+```text
+# bench_air_node_serial_json
+# I2C pin plan: SDA=GPIO8 SCL=GPIO9
+```
+
+Expected packet behavior:
+
+- one JSON object per line
+- one packet about every 5 seconds
+- `sht45` and `bme680` both present when wiring is healthy
+
+## Stage 4: validate locally
+
+From `repo/programs/resilient-home-intelligence/software/ingest-service/` run:
+
+```bash
+python3 scripts/ingest_packet.py packet.json
+```
+
+If you prefer stdin:
+
+```bash
+python3 scripts/ingest_packet.py < packet.json
+```
+
+## Pass criteria
+
+- scanner finds `0x44` first
+- scanner finds `0x44` plus `0x76` or `0x77` after BME680 is added
+- serial JSON sketch prints one valid packet line every 5 seconds
+- `python3 scripts/ingest_packet.py packet.json` succeeds
+- normalized output includes `temperature_c_primary`, `relative_humidity_pct_primary`, `pressure_hpa`, and `gas_resistance_ohm`
+
+## Known first-build limitations
+
+- `observed_at` is still a placeholder timestamp until time sync is added
+- `wifi_connected` remains `false`
+- gas resistance is useful for trend inspection, not calibrated AQI
+
+## If something fails
+
+- no `0x44`: recheck SHT45 power, solder, and `GPIO8`/`GPIO9` wiring
+- no BME680 address: recheck `SDI` to `SDA`, `SCK` to `SCL`, and power
+- JSON does not validate: copy a full packet line, not a boot comment
+- only one sensor reports `present: false`: inspect that sensor’s solder joints and bus wiring

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/operator-runbook.md
@@ -93,6 +93,13 @@ If you prefer stdin:
 python3 scripts/ingest_packet.py < packet.json
 ```
 
+If you captured a whole serial monitor log with `#` boot lines, extract the newest packet first:
+
+```bash
+python3 scripts/extract_latest_packet.py serial.log --output packet.json
+python3 scripts/ingest_packet.py packet.json
+```
+
 ## Pass criteria
 
 - scanner finds `0x44` first
@@ -112,4 +119,5 @@ python3 scripts/ingest_packet.py < packet.json
 - no `0x44`: recheck SHT45 power, solder, and `GPIO8`/`GPIO9` wiring
 - no BME680 address: recheck `SDI` to `SDA`, `SCK` to `SCL`, and power
 - JSON does not validate: copy a full packet line, not a boot comment
+- mixed serial log is messy: run `python3 scripts/extract_latest_packet.py serial.log --output packet.json`
 - only one sensor reports `present: false`: inspect that sensor’s solder joints and bus wiring

--- a/programs/resilient-home-intelligence/hardware/bench-air-node/serial-json-contract.md
+++ b/programs/resilient-home-intelligence/hardware/bench-air-node/serial-json-contract.md
@@ -63,6 +63,8 @@ During first-build bring-up it is fine to print a few human-readable boot messag
 - `bme680`: pressure and gas-trend source, plus secondary temp and humidity
 - `wifi_connected`: `false` is expected for serial-only bring-up
 
+If Wi-Fi credentials are configured for time sync, `wifi_connected` may be `true` even when packets are still only being inspected over serial.
+
 ## First-build fallback for time
 
 If the node does not yet have a real clock, use one of these approaches consistently:
@@ -70,7 +72,14 @@ If the node does not yet have a real clock, use one of these approaches consiste
 - emit boot-relative timestamps only in debug logs and wait to emit JSON packets until time is available
 - emit a placeholder RFC 3339 timestamp and clearly document that it is provisional during serial-only bring-up
 
-The preferred path for the MVP is still to emit valid RFC 3339 timestamps once Wi-Fi or another clock source exists.
+The preferred path for the MVP is to emit valid RFC 3339 UTC timestamps once Wi-Fi/NTP or another clock source exists.
+
+## Current firmware behavior
+
+The current bench-air firmware scaffold supports two modes:
+
+- serial-only bring-up: blank Wi-Fi credentials, placeholder `observed_at`, `wifi_connected: false`
+- Wi-Fi-assisted time sync: configured credentials, NTP-backed UTC `observed_at`, `wifi_connected: true` when connected
 
 ## Serial line example
 

--- a/programs/resilient-home-intelligence/software/inference-engine/scripts/serve_inference_api.py
+++ b/programs/resilient-home-intelligence/software/inference-engine/scripts/serve_inference_api.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from infer_parcel_state import InferenceError, infer_parcel_state
+
+
+MODEL_INFO = {
+    "model_id": "hazard-logic-v0",
+    "mode": "rules-based",
+    "status": "active",
+}
+
+
+class InferenceRequestHandler(BaseHTTPRequestHandler):
+    server_version = "RHIInference/0.1"
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(content_length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise InferenceError(f"request body: invalid JSON: {exc}") from exc
+
+    def do_GET(self):
+        if self.path == "/v1/inference/health":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "service": "inference-engine",
+                    "model": MODEL_INFO,
+                },
+            )
+            return
+
+        if self.path == "/v1/inference/models":
+            self._send_json(HTTPStatus.OK, {"models": [MODEL_INFO]})
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self):
+        if self.path != "/v1/inference/parcel-state":
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+
+        computed_at = self.headers.get("X-RHI-Computed-At")
+        try:
+            payload = self._read_json()
+            parcel_state = infer_parcel_state(payload, computed_at=computed_at)
+        except (InferenceError, KeyError) as exc:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {
+                    "ok": False,
+                    "error": "invalid_observation",
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        self._send_json(
+            HTTPStatus.ACCEPTED,
+            {
+                "ok": True,
+                "parcel_state": parcel_state,
+            },
+        )
+
+    def log_message(self, format, *args):
+        return
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a tiny local inference API for normalized observation testing.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind.")
+    parser.add_argument("--port", type=int, default=8788, help="Port to listen on.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), InferenceRequestHandler)
+    print(f"Listening on http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/programs/resilient-home-intelligence/software/ingest-service/README.md
+++ b/programs/resilient-home-intelligence/software/ingest-service/README.md
@@ -41,6 +41,15 @@ The next reference scaffold is `scripts/normalize_packet.py`. It reads a node pa
 
 `scripts/ingest_packet.py` is the simplest local end-to-end entrypoint for bench bring-up. It accepts a packet from a file or stdin, validates it, and prints the normalized observation.
 
+`scripts/extract_latest_packet.py` pulls the newest JSON packet out of a mixed serial log so boot comments and other monitor noise do not need to be removed by hand.
+
+`scripts/serve_ingest_api.py` is the first minimal HTTP wrapper. It exposes:
+- `GET /v1/ingest/health`
+- `GET /v1/ingest/schemas`
+- `POST /v1/ingest/node-packets`
+
+The server is intentionally lightweight and uses the same normalization code as the local CLI path.
+
 ## Local smoke-test path
 
 From `repo/programs/resilient-home-intelligence/software/ingest-service/`:
@@ -58,6 +67,11 @@ When the ESP32 starts emitting serial JSON:
 1. Copy one packet line into `packet.json`
 2. Run `python3 scripts/ingest_packet.py packet.json`
 3. Confirm the packet validates and normalizes cleanly
+
+If you saved a full serial log instead of a clean packet file:
+
+1. Run `python3 scripts/extract_latest_packet.py serial.log --output packet.json`
+2. Run `python3 scripts/ingest_packet.py packet.json`
 
 The expected first-build serial payload shape is documented in `../../hardware/bench-air-node/serial-json-contract.md`.
 The full first-build operator path is documented in `../../hardware/bench-air-node/operator-runbook.md`.

--- a/programs/resilient-home-intelligence/software/ingest-service/README.md
+++ b/programs/resilient-home-intelligence/software/ingest-service/README.md
@@ -60,3 +60,4 @@ When the ESP32 starts emitting serial JSON:
 3. Confirm the packet validates and normalizes cleanly
 
 The expected first-build serial payload shape is documented in `../../hardware/bench-air-node/serial-json-contract.md`.
+The full first-build operator path is documented in `../../hardware/bench-air-node/operator-runbook.md`.

--- a/programs/resilient-home-intelligence/software/ingest-service/scripts/extract_latest_packet.py
+++ b/programs/resilient-home-intelligence/software/ingest-service/scripts/extract_latest_packet.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from validate_examples import ValidationError
+
+
+def iter_candidate_lines(text: str):
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            continue
+        if not line.startswith("{"):
+            continue
+        yield line
+
+
+def extract_latest_packet(text: str) -> dict:
+    latest_packet = None
+    latest_error = None
+
+    for line in iter_candidate_lines(text):
+        try:
+            latest_packet = json.loads(line)
+            latest_error = None
+        except json.JSONDecodeError as exc:
+            latest_error = exc
+
+    if latest_packet is None:
+        if latest_error is not None:
+            raise ValidationError(f"no valid JSON packet found: {latest_error}")
+        raise ValidationError("no candidate JSON packet lines found")
+
+    return latest_packet
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract the newest JSON packet line from a mixed serial log."
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default="-",
+        help="Path to a serial log file, or '-' to read the log from stdin.",
+    )
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Path to write the extracted packet JSON, or '-' for stdout.",
+    )
+    return parser.parse_args()
+
+
+def read_text(input_value: str) -> str:
+    if input_value == "-":
+        return sys.stdin.read()
+    return Path(input_value).resolve().read_text(encoding="utf-8")
+
+
+def write_packet(packet: dict, output_value: str):
+    serialized = json.dumps(packet, indent=2, sort_keys=True)
+    if output_value == "-":
+        print(serialized)
+        return
+    Path(output_value).resolve().write_text(serialized + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        packet = extract_latest_packet(read_text(args.input))
+        write_packet(packet, args.output)
+    except (ValidationError, FileNotFoundError) as exc:
+        print(f"ERROR {args.input}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/programs/resilient-home-intelligence/software/ingest-service/scripts/serve_ingest_api.py
+++ b/programs/resilient-home-intelligence/software/ingest-service/scripts/serve_ingest_api.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from normalize_packet import normalize_packet
+from validate_examples import ValidationError
+
+
+SUPPORTED_SCHEMAS = ["rhi.bench-air.v1"]
+
+
+class IngestRequestHandler(BaseHTTPRequestHandler):
+    server_version = "RHIIngest/0.1"
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(content_length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValidationError(f"request body: invalid JSON: {exc}") from exc
+
+    def do_GET(self):
+        if self.path == "/v1/ingest/health":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "service": "ingest-service",
+                    "supported_schemas": SUPPORTED_SCHEMAS,
+                },
+            )
+            return
+
+        if self.path == "/v1/ingest/schemas":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "schemas": [
+                        {
+                            "schema_version": "rhi.bench-air.v1",
+                            "status": "active",
+                        }
+                    ]
+                },
+            )
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self):
+        if self.path != "/v1/ingest/node-packets":
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+
+        parcel_id = self.headers.get("X-RHI-Parcel-Id", "parcel_demo_001")
+        try:
+            payload = self._read_json()
+            normalized = normalize_packet(payload, parcel_id=parcel_id)
+        except (ValidationError, KeyError) as exc:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {
+                    "ok": False,
+                    "error": "invalid_packet",
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        self._send_json(
+            HTTPStatus.ACCEPTED,
+            {
+                "ok": True,
+                "normalized_observation": normalized,
+            },
+        )
+
+    def log_message(self, format, *args):
+        return
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a tiny local ingest API for bench-air packet testing.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind.")
+    parser.add_argument("--port", type=int, default=8787, help="Port to listen on.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), IngestRequestHandler)
+    print(f"Listening on http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/programs/resilient-home-intelligence/software/parcel-platform/scripts/serve_parcel_api.py
+++ b/programs/resilient-home-intelligence/software/parcel-platform/scripts/serve_parcel_api.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from format_parcel_view import ParcelViewError, build_parcel_view
+
+
+class ParcelPlatformRequestHandler(BaseHTTPRequestHandler):
+    server_version = "RHIParcelPlatform/0.1"
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(content_length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ParcelViewError(f"request body: invalid JSON: {exc}") from exc
+
+    def do_GET(self):
+        if self.path == "/v1/parcel-platform/health":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "service": "parcel-platform",
+                },
+            )
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self):
+        if self.path != "/v1/parcels/state/view":
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+
+        try:
+            payload = self._read_json()
+            parcel_view = build_parcel_view(payload)
+        except (ParcelViewError, KeyError) as exc:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {
+                    "ok": False,
+                    "error": "invalid_parcel_state",
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "ok": True,
+                "parcel_view": parcel_view,
+            },
+        )
+
+    def log_message(self, format, *args):
+        return
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a tiny local parcel-platform API for parcel-state formatting.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind.")
+    parser.add_argument("--port", type=int, default=8789, help="Port to listen on.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), ParcelPlatformRequestHandler)
+    print(f"Listening on http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rhi_http_smoke_check.sh
+++ b/scripts/rhi_http_smoke_check.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+INGEST_PID=""
+INFERENCE_PID=""
+PARCEL_PID=""
+
+cleanup() {
+  for pid in "$PARCEL_PID" "$INFERENCE_PID" "$INGEST_PID"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup EXIT
+
+echo "[rhi-http-check] starting ingest api"
+python3 programs/resilient-home-intelligence/software/ingest-service/scripts/serve_ingest_api.py --host 127.0.0.1 --port 8787 >/tmp/rhi-ingest.log 2>&1 &
+INGEST_PID=$!
+
+echo "[rhi-http-check] starting inference api"
+python3 programs/resilient-home-intelligence/software/inference-engine/scripts/serve_inference_api.py --host 127.0.0.1 --port 8788 >/tmp/rhi-inference.log 2>&1 &
+INFERENCE_PID=$!
+
+echo "[rhi-http-check] starting parcel-platform api"
+python3 programs/resilient-home-intelligence/software/parcel-platform/scripts/serve_parcel_api.py --host 127.0.0.1 --port 8789 >/tmp/rhi-parcel.log 2>&1 &
+PARCEL_PID=$!
+
+sleep 1
+
+echo "[rhi-http-check] checking health endpoints"
+curl -s http://127.0.0.1:8787/v1/ingest/health >/tmp/rhi-ingest-health.json
+curl -s http://127.0.0.1:8788/v1/inference/health >/tmp/rhi-inference-health.json
+curl -s http://127.0.0.1:8789/v1/parcel-platform/health >/tmp/rhi-parcel-health.json
+
+echo "[rhi-http-check] posting node packet to ingest api"
+curl -s -X POST http://127.0.0.1:8787/v1/ingest/node-packets \
+  -H 'Content-Type: application/json' \
+  -H 'X-RHI-Parcel-Id: parcel_demo_http' \
+  --data-binary @programs/resilient-home-intelligence/docs/data-model/examples/node-observation.example.json \
+  >/tmp/rhi-ingest-response.json
+
+echo "[rhi-http-check] posting normalized observation to inference api"
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+payload = json.loads(Path("/tmp/rhi-ingest-response.json").read_text(encoding="utf-8"))
+Path("/tmp/rhi-normalized-from-http.json").write_text(
+    json.dumps(payload["normalized_observation"]),
+    encoding="utf-8",
+)
+PY
+
+curl -s -X POST http://127.0.0.1:8788/v1/inference/parcel-state \
+  -H 'Content-Type: application/json' \
+  -H 'X-RHI-Computed-At: 2026-03-30T19:46:00Z' \
+  --data-binary @/tmp/rhi-normalized-from-http.json \
+  >/tmp/rhi-inference-response.json
+
+echo "[rhi-http-check] posting parcel state to parcel-platform api"
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+payload = json.loads(Path("/tmp/rhi-inference-response.json").read_text(encoding="utf-8"))
+Path("/tmp/rhi-parcel-state-from-http.json").write_text(
+    json.dumps(payload["parcel_state"]),
+    encoding="utf-8",
+)
+PY
+
+curl -s -X POST http://127.0.0.1:8789/v1/parcels/state/view \
+  -H 'Content-Type: application/json' \
+  --data-binary @/tmp/rhi-parcel-state-from-http.json \
+  >/tmp/rhi-parcel-response.json
+
+echo "[rhi-http-check] checking response shapes"
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+def load(path: str):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+ingest_health = load("/tmp/rhi-ingest-health.json")
+inference_health = load("/tmp/rhi-inference-health.json")
+parcel_health = load("/tmp/rhi-parcel-health.json")
+ingest_payload = load("/tmp/rhi-ingest-response.json")
+inference_payload = load("/tmp/rhi-inference-response.json")
+parcel_payload = load("/tmp/rhi-parcel-response.json")
+
+assert ingest_health["ok"] is True
+assert inference_health["ok"] is True
+assert parcel_health["ok"] is True
+
+normalized = ingest_payload["normalized_observation"]
+parcel_state = inference_payload["parcel_state"]
+parcel_view = parcel_payload["parcel_view"]
+
+for key in ("node_id", "parcel_id", "values", "provenance"):
+    if key not in normalized:
+        raise SystemExit(f"normalized observation missing {key}")
+
+for key in ("shelter_status", "reentry_status", "egress_status", "asset_risk_status"):
+    if key not in parcel_state:
+        raise SystemExit(f"parcel_state missing {key}")
+
+for key in ("statuses", "summary", "confidence", "evidence_mode"):
+    if key not in parcel_view:
+        raise SystemExit(f"parcel_view missing {key}")
+
+print("PASS rhi-http-check")
+PY


### PR DESCRIPTION
## What changed
- add first-build bench-air firmware setup and serial packet scaffolding
- add reference pipeline scripts from raw packet to parcel view
- add local HTTP wrappers for ingest, inference, and parcel-platform stages
- add repo demo entrypoints and smoke checks for file-based and HTTP-based flows

## Why
This packages the first end-to-end executable reference path for the bench-air-node MVP so firmware bring-up, ingest normalization, inference, and parcel presentation can be exercised consistently.

## Validation
- `make rhi-demo`
- `make rhi-validate`
- `make rhi-check`
- `make rhi-http-check`
- verified localhost ingest, inference, and parcel-platform endpoints manually with example payloads

## Notes
- the branch still has additional local uncommitted docs/legal/governance work that is not part of this PR
- this PR focuses on the pushed commits already on `codex/bench-air-node-first-build`