### PR TITLE
Evolve release site into docs hub with navigation, dark mode, and content system

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "rhi-site",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 4321,
+      "cwd": "programs/resilient-home-intelligence/docs/release/2026-04-14/site"
+    }
+  ]
+}

--- a/programs/resilient-home-intelligence/docs/data-model/.claude/launch.json
+++ b/programs/resilient-home-intelligence/docs/data-model/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "rhi-site",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["../release/2026-04-14/site/node_modules/astro/astro.js", "dev", "--host", "--root", "../release/2026-04-14/site", "--port", "4321"],
+      "port": 4321,
+      "autoPort": false
+    }
+  ]
+}

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/.claude/launch.json
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "rhi-site",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["astro", "dev", "--host"],
+      "port": 4321
+    }
+  ]
+}

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/astro.config.mjs
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/astro.config.mjs
@@ -1,10 +1,14 @@
 import { defineConfig } from "astro/config";
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
+  site: "https://resilient-home-intelligence.org",
   output: "static",
   build: {
     format: "file"
   },
+  integrations: [mdx(), sitemap()],
   server: {
     host: true
   }

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/package-lock.json
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "rhi-open-release-site",
       "devDependencies": {
+        "@astrojs/mdx": "^4.3.14",
+        "@astrojs/sitemap": "^3.7.2",
         "astro": "^5.0.0"
       },
       "engines": {
@@ -56,6 +58,34 @@
         "vfile": "^6.0.3"
       }
     },
+    "node_modules/@astrojs/mdx": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.14.tgz",
+      "integrity": "sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "6.3.11",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.15.0",
+        "es-module-lexer": "^1.7.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0"
+      }
+    },
     "node_modules/@astrojs/prism": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
@@ -67,6 +97,28 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1102,6 +1154,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1580,6 +1670,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1600,6 +1700,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1615,6 +1722,26 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1642,6 +1769,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/ansi-align": {
@@ -1752,6 +1889,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1778,6 +1922,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/astro": {
@@ -1995,6 +2149,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -2048,6 +2213,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -2429,6 +2605,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -2482,6 +2692,94 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -2706,6 +3004,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -2724,6 +3051,34 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2835,6 +3190,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -2843,6 +3205,43 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -2869,6 +3268,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -2983,6 +3393,19 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-table": {
@@ -3151,6 +3574,87 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -3440,6 +3944,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -3483,6 +4094,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -3695,6 +4334,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -4020,6 +4685,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -4164,6 +4856,77 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -4240,6 +5003,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
@@ -4269,6 +5048,21 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4545,6 +5339,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -4556,6 +5370,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -4578,6 +5402,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4626,6 +5457,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/svgo": {
@@ -4788,6 +5639,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -4868,6 +5726,20 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/package.json
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/package.json
@@ -11,6 +11,8 @@
     "node": ">=18.17.0"
   },
   "devDependencies": {
+    "@astrojs/mdx": "^4.3.14",
+    "@astrojs/sitemap": "^3.7.2",
     "astro": "^5.0.0"
   }
 }

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/Accordion.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/Accordion.astro
@@ -1,0 +1,15 @@
+---
+const { title, open = false } = Astro.props;
+---
+
+<details class="accordion" open={open}>
+  <summary class="accordion-summary">
+    <span class="accordion-title">{title}</span>
+    <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </summary>
+  <div class="accordion-content">
+    <slot />
+  </div>
+</details>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/Breadcrumbs.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/Breadcrumbs.astro
@@ -1,0 +1,57 @@
+---
+const currentPath = Astro.url.pathname;
+const segments = currentPath.split("/").filter(Boolean);
+
+const labels: Record<string, string> = {
+  docs: "Docs",
+  "data-model": "Data Model",
+  hardware: "Hardware",
+  privacy: "Privacy & Governance",
+  system: "System Overview",
+  "build-guides": "Build Guides",
+  "pilot-playbooks": "Pilot Playbooks",
+  legal: "Legal",
+  "getting-started": "Getting Started",
+  for: "For"
+};
+
+function segmentLabel(seg: string) {
+  if (labels[seg]) return labels[seg];
+  return seg
+    .replace(/\.html$/, "")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+interface Crumb {
+  label: string;
+  href: string;
+  current: boolean;
+}
+
+const crumbs: Crumb[] = segments.map((seg, i) => {
+  const href = "/" + segments.slice(0, i + 1).join("/") + (i < segments.length - 1 ? "" : "");
+  return {
+    label: segmentLabel(seg),
+    href,
+    current: i === segments.length - 1
+  };
+});
+---
+
+{crumbs.length > 1 && (
+  <nav class="breadcrumbs" aria-label="Breadcrumbs">
+    <ol>
+      {crumbs.map((crumb, i) => (
+        <li>
+          {crumb.current ? (
+            <span aria-current="page">{crumb.label}</span>
+          ) : (
+            <a href={crumb.href}>{crumb.label}</a>
+          )}
+          {i < crumbs.length - 1 && <span class="breadcrumb-sep" aria-hidden="true">/</span>}
+        </li>
+      ))}
+    </ol>
+  </nav>
+)}

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/DocsSidebar.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/DocsSidebar.astro
@@ -1,0 +1,45 @@
+---
+import { docsNav } from "../data/docs-nav";
+
+const currentPath = Astro.url.pathname;
+
+function isActive(href: string) {
+  const normalized = currentPath.replace(/\/$/, "").replace(/\.html$/, "");
+  const hrefNormalized = href.replace(/\/$/, "").replace(/\.html$/, "");
+  return normalized === hrefNormalized;
+}
+
+function sectionHasActive(items: { href: string }[]) {
+  return items.some((item) => isActive(item.href));
+}
+---
+
+<nav class="docs-sidebar" aria-label="Documentation">
+  <div class="docs-sidebar-inner">
+    <a class="docs-sidebar-heading" href="/docs">Docs</a>
+    {docsNav.map((section) => (
+      section.items.length > 0 ? (
+        <details class="docs-sidebar-section" open={sectionHasActive(section.items)}>
+          <summary class="docs-sidebar-section-title">{section.title}</summary>
+          <ul class="docs-sidebar-list">
+            {section.items.map((item) => (
+              <li>
+                <a
+                  href={item.href}
+                  class:list={["docs-sidebar-link", { active: isActive(item.href) }]}
+                  aria-current={isActive(item.href) ? "page" : undefined}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : (
+        <div class="docs-sidebar-section">
+          <span class="docs-sidebar-section-title docs-sidebar-section-empty">{section.title}</span>
+        </div>
+      )
+    ))}
+  </div>
+</nav>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/PageHero.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/PageHero.astro
@@ -9,15 +9,28 @@ const {
   actions = [],
   asideLabel,
   asideTitle,
-  asideItems = []
+  asideItems = [],
+  versionBar,
+  heroImage
 } = Astro.props;
 ---
+
+{versionBar && (
+  <div class="version-bar">
+    <span class="version-bar-label">{versionBar}</span>
+    {meta.length > 0 && (
+      <div class="version-bar-meta">
+        {meta.map((item) => <span>{item}</span>)}
+      </div>
+    )}
+  </div>
+)}
 
 <header class="hero">
   <div class="hero-top">
     <p class="eyebrow">{eyebrow}</p>
     {pageLinks.length > 0 && (
-      <nav class="top-nav" aria-label="Section links">
+      <nav class="section-nav" aria-label="Page sections">
         {pageLinks.map((link) => (
           <a href={link.href}>{link.label}</a>
         ))}
@@ -29,7 +42,7 @@ const {
       <h1>{title}</h1>
       <p class="lede">{lede}</p>
       {tagline && <p class="hero-tagline">{tagline}</p>}
-      {meta.length > 0 && (
+      {!versionBar && meta.length > 0 && (
         <div class="meta-strip" aria-label="Release metadata">
           {meta.map((item) => <span>{item}</span>)}
         </div>
@@ -47,7 +60,11 @@ const {
         </div>
       )}
     </div>
-    {(asideTitle || asideItems.length > 0) && (
+    {heroImage ? (
+      <div class="hero-image-wrap">
+        <img src={heroImage.src} alt={heroImage.alt || ""} class="hero-image" loading="eager" />
+      </div>
+    ) : (asideTitle || asideItems.length > 0) ? (
       <aside class="hero-aside">
         {asideLabel && <p class="kicker">{asideLabel}</p>}
         {asideTitle && <h2>{asideTitle}</h2>}
@@ -57,6 +74,6 @@ const {
           </ul>
         )}
       </aside>
-    )}
+    ) : null}
   </div>
 </header>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SchemaViewer.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SchemaViewer.astro
@@ -1,0 +1,75 @@
+---
+import fs from "node:fs";
+import path from "node:path";
+
+const { schemaPath, examplePath, label = "Schema" } = Astro.props;
+
+const DATA_MODEL_DIR = path.resolve("../../docs/data-model");
+
+let schemaJson = "";
+let exampleJson = "";
+
+if (schemaPath) {
+  try {
+    const fullPath = path.join(DATA_MODEL_DIR, "schemas", schemaPath);
+    schemaJson = fs.readFileSync(fullPath, "utf-8");
+  } catch {
+    schemaJson = "";
+  }
+}
+
+if (examplePath) {
+  try {
+    const fullPath = path.join(DATA_MODEL_DIR, "examples", examplePath);
+    exampleJson = fs.readFileSync(fullPath, "utf-8");
+  } catch {
+    exampleJson = "";
+  }
+}
+
+const hasSchema = schemaJson.length > 0;
+const hasExample = exampleJson.length > 0;
+const hasBoth = hasSchema && hasExample;
+const tabId = `sv-${Math.random().toString(36).slice(2, 8)}`;
+---
+
+{(hasSchema || hasExample) && (
+  <div class="schema-viewer">
+    {hasBoth ? (
+      <div class="schema-tabs">
+        <input
+          type="radio"
+          name={tabId}
+          id={`${tabId}-schema`}
+          class="schema-tab-input"
+          checked
+        />
+        <label for={`${tabId}-schema`} class="schema-tab-label">Schema</label>
+        <input
+          type="radio"
+          name={tabId}
+          id={`${tabId}-example`}
+          class="schema-tab-input"
+        />
+        <label for={`${tabId}-example`} class="schema-tab-label">Example</label>
+
+        <div class="schema-tab-panel" data-tab="schema">
+          <pre><code>{schemaJson}</code></pre>
+        </div>
+        <div class="schema-tab-panel" data-tab="example">
+          <pre><code>{exampleJson}</code></pre>
+        </div>
+      </div>
+    ) : hasSchema ? (
+      <details class="schema-details">
+        <summary class="schema-details-summary">{label}</summary>
+        <pre><code>{schemaJson}</code></pre>
+      </details>
+    ) : (
+      <details class="schema-details">
+        <summary class="schema-details-summary">Example</summary>
+        <pre><code>{exampleJson}</code></pre>
+      </details>
+    )}
+  </div>
+)}

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SearchDialog.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SearchDialog.astro
@@ -1,0 +1,71 @@
+---
+---
+
+<dialog class="search-dialog" id="search-dialog">
+  <div class="search-dialog-inner">
+    <div class="search-dialog-header">
+      <span class="search-dialog-title">Search docs</span>
+      <button class="search-dialog-close" type="button" aria-label="Close search">
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+          <path d="M4 4l10 10M14 4L4 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+    <div id="pagefind-container"></div>
+  </div>
+</dialog>
+
+<script is:inline>
+  (function() {
+    var dialog = document.getElementById('search-dialog');
+    var trigger = document.getElementById('search-trigger');
+    var closeBtn = dialog && dialog.querySelector('.search-dialog-close');
+    var loaded = false;
+
+    function openSearch() {
+      if (!dialog) return;
+      dialog.showModal();
+      if (!loaded) {
+        loaded = true;
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = '/pagefind/pagefind-ui.css';
+        document.head.appendChild(link);
+        var script = document.createElement('script');
+        script.src = '/pagefind/pagefind-ui.js';
+        script.onload = function() {
+          if (window.PagefindUI) {
+            new window.PagefindUI({
+              element: '#pagefind-container',
+              showSubResults: true,
+              showImages: false
+            });
+          }
+          var input = dialog.querySelector('input');
+          if (input) input.focus();
+        };
+        document.head.appendChild(script);
+      } else {
+        var input = dialog.querySelector('input');
+        if (input) input.focus();
+      }
+    }
+
+    if (trigger) trigger.addEventListener('click', openSearch);
+    if (closeBtn) closeBtn.addEventListener('click', function() { dialog.close(); });
+    if (dialog) dialog.addEventListener('click', function(e) {
+      if (e.target === dialog) dialog.close();
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        if (dialog && dialog.open) {
+          dialog.close();
+        } else {
+          openSearch();
+        }
+      }
+    });
+  })();
+</script>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SiteNav.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/SiteNav.astro
@@ -1,0 +1,86 @@
+---
+import { repoLinks } from "../lib/repo-links";
+
+const currentPath = Astro.url.pathname;
+
+const navLinks = [
+  { href: "/docs", label: "Docs" },
+  { href: "/dataset.html", label: "Dataset" },
+  { href: "/faq.html", label: "FAQ" },
+  { href: "/release-notes.html", label: "Release notes" }
+];
+
+function isActive(href: string) {
+  if (href === "/docs") {
+    return currentPath.startsWith("/docs");
+  }
+  return currentPath === href || currentPath === href.replace(".html", "");
+}
+---
+
+<nav class="site-nav" aria-label="Main">
+  <div class="site-nav-inner">
+    <a class="site-nav-brand" href="/">
+      <span class="site-nav-logo" aria-hidden="true">&#x1F3E0;</span>
+      <span class="site-nav-name">RHI</span>
+    </a>
+
+    <div class="site-nav-links" id="nav-links">
+      {navLinks.map((link) => (
+        <a
+          href={link.href}
+          class:list={["site-nav-link", { active: isActive(link.href) }]}
+          aria-current={isActive(link.href) ? "page" : undefined}
+        >
+          {link.label}
+        </a>
+      ))}
+      <a class="site-nav-link site-nav-link--external" href={repoLinks.repoHome}>
+        GitHub
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M3.5 1.5h7v7M10 2L2 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
+    </div>
+
+    <div class="site-nav-actions">
+      <button class="site-nav-search-btn" type="button" aria-label="Search" id="search-trigger">
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+          <circle cx="7.5" cy="7.5" r="5" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M11.5 11.5L16 16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        <span class="site-nav-search-hint">
+          <kbd>&#8984;K</kbd>
+        </span>
+      </button>
+      <button class="site-nav-theme-btn" type="button" aria-label="Toggle dark mode" aria-pressed="false" id="theme-toggle">
+        <svg class="icon-sun" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+          <circle cx="9" cy="9" r="4" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.3 3.3l1.4 1.4M13.3 13.3l1.4 1.4M3.3 14.7l1.4-1.4M13.3 4.7l1.4-1.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        <svg class="icon-moon" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+          <path d="M15.1 10.4A7 7 0 017.6 2.9 7 7 0 1015.1 10.4z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+    </div>
+
+    <details class="site-nav-mobile">
+      <summary class="site-nav-hamburger" aria-label="Open navigation menu">
+        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+          <path d="M3 6h16M3 11h16M3 16h16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </summary>
+      <div class="site-nav-drawer">
+        {navLinks.map((link) => (
+          <a
+            href={link.href}
+            class:list={["site-nav-drawer-link", { active: isActive(link.href) }]}
+          >
+            {link.label}
+          </a>
+        ))}
+        <a class="site-nav-drawer-link" href={repoLinks.repoHome}>GitHub</a>
+      </div>
+    </details>
+  </div>
+</nav>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/StatusBadge.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/components/StatusBadge.astro
@@ -1,0 +1,17 @@
+---
+const { status = "stable", version } = Astro.props;
+
+const statusColors: Record<string, string> = {
+  stable: "var(--forest)",
+  beta: "var(--accent)",
+  draft: "var(--muted)",
+  deprecated: "#9e3030"
+};
+
+const color = statusColors[status] || "var(--muted)";
+---
+
+<span class="status-badge" style={`--badge-color: ${color}`}>
+  {status}
+  {version && <span class="status-badge-version">{version}</span>}
+</span>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content.config.ts
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content.config.ts
@@ -1,0 +1,31 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const docs = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/docs" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    section: z.enum([
+      "getting-started",
+      "data-model",
+      "privacy",
+      "hardware",
+      "system",
+      "build-guides",
+      "pilot-playbooks",
+      "legal"
+    ]),
+    audience: z
+      .array(z.enum(["homeowner", "builder", "researcher", "contributor"]))
+      .optional()
+      .default([]),
+    order: z.number().optional().default(100),
+    draft: z.boolean().optional().default(false),
+    schema_file: z.string().optional(),
+    example_file: z.string().optional(),
+    status: z.enum(["stable", "beta", "draft", "deprecated"]).optional()
+  })
+});
+
+export const collections = { docs };

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/evidence-mode-and-observability.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/evidence-mode-and-observability.md
@@ -1,0 +1,80 @@
+---
+title: Evidence Mode and Observability
+description: How the platform distinguishes direct observation from inference, and how that distinction appears in parcel-state outputs.
+section: data-model
+audience: [builder, researcher, homeowner]
+order: 11
+status: draft
+---
+
+## Purpose
+
+Define how the platform distinguishes direct observation from inference, and how that distinction should appear in parcel-state outputs.
+
+## Core distinction
+
+The platform estimates parcel conditions from evidence layers. It does not observe every parcel condition directly.
+
+This means the system must separate:
+
+- what was directly measured by a sensor at a specific install location
+- what was inferred from that measurement plus parcel context
+- what was inferred from public context without local confirmation
+
+## Directly measurable examples
+
+- air temperature at a node location
+- humidity at a node location
+- pressure at a node location
+- gas-resistance trend at a node location
+- later: PM concentration at a node location
+- later: water depth at a flood-node low point
+
+## Not directly measurable from one point sensor
+
+- parcel-wide smoke condition
+- parcel-wide outdoor heat burden
+- parcel-wide runoff extent
+- safe-to-shelter, safe-to-reenter, or safe-to-egress determinations
+
+Those outputs are always interpreted estimates, even when local evidence exists.
+
+## Current parcel-state enum
+
+- `local_only`
+- `local_plus_public`
+- `public_only`
+- `insufficient`
+
+These values remain acceptable for MVP use because they are easy to explain in the UI. They should be interpreted as evidence-composition modes, not as direct statements about truth.
+
+## Observability rules
+
+- A local node does not convert a parcel estimate into direct parcel truth.
+- Observability depends on hazard, node type, install role, freshness, and sensor quality.
+- A bench-air-node in `indoor` or `sheltered` mode is low-observability evidence for parcel-wide smoke and outdoor heat conditions.
+- A future outdoor PM mast has higher smoke observability than a bench-air-node.
+- A future flood-node installed at a documented runoff low point has higher flood observability than a generic outdoor node.
+
+## Confidence rules tied to observability
+
+Confidence should fall when:
+
+- evidence comes from a location with weak hazard relevance
+- local evidence is stale
+- only one point observation supports a parcel-wide conclusion
+- public context and local context disagree
+- install metadata is missing
+
+Confidence may increase when:
+
+- evidence comes from a hazard-relevant node type and install role
+- local and public evidence agree
+- recent observations are available
+- parcel priors are explicit rather than guessed
+
+## UI and API guidance
+
+- `evidence_mode` should be shown next to confidence and freshness, not hidden behind a tooltip.
+- Reasons should explicitly mention whether a conclusion is based on local measurements, public context, or both.
+- If evidence is weak, the platform should prefer `unknown` over a confident-sounding warning or reassurance.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/explanation-payload-schema.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/explanation-payload-schema.md
@@ -1,0 +1,77 @@
+---
+title: Explanation Payload Schema
+description: Structured explanation object accompanying parcel-state outputs for UI rendering, audit, and notifications.
+section: data-model
+audience: [builder, researcher]
+order: 10
+status: draft
+---
+
+## Purpose
+
+Define a structured explanation object that accompanies parcel-state outputs so downstream systems do not need to reconstruct explanation logic from flat reason strings alone.
+
+## Why this payload exists
+
+The repo already carries homeowner-readable `reasons` and a compact `provenance_summary`, but mixed-source parcel inference now needs a more structured object for:
+
+- explanation UI rendering
+- audit and debugging
+- future notifications
+- safe filtering of evidence detail by audience
+
+## Minimum explanation payload
+
+```json
+{
+  "headline": "Estimate uses local, shared, and public evidence with limited parcel certainty.",
+  "basis": {
+    "evidence_mode": "local_plus_public",
+    "inference_basis": "local_plus_shared_plus_public",
+    "confidence_band": "medium"
+  },
+  "drivers": [
+    "Regional smoke context suggests modest smoke concern.",
+    "Shared neighborhood signals suggest nearby smoke concern."
+  ],
+  "limitations": [
+    "No parcel low-point flood sensor is present.",
+    "The local node is installed as a reference indoor node."
+  ],
+  "evidence_contributions": [
+    {
+      "contribution_id": "local_gas_trend",
+      "source_class": "local",
+      "source_name": "bench-air-01",
+      "role": "driver",
+      "summary": "Indoor gas-resistance trend shows a moderate change.",
+      "hazards": ["smoke"],
+      "weight": 0.32,
+      "visibility": "homeowner_safe"
+    }
+  ],
+  "source_breakdown": {
+    "local": true,
+    "shared": true,
+    "public": true,
+    "parcel_context": true,
+    "system": false
+  }
+}
+```
+
+## Field notes
+
+- `headline` -- One sentence suitable for a parcel detail panel or alert preview.
+- `basis` -- Machine-usable explanation metadata.
+- `drivers` -- Main contributing factors behind the current estimate.
+- `limitations` -- Missing evidence, siting constraints, freshness issues, or other caution points.
+- `evidence_contributions` -- Stable, source-aware explanation primitives suitable for UI grouping, debugging, and future notifications.
+- `source_breakdown` -- Quick machine-readable view of which source classes contributed.
+
+## Design rules
+
+- The explanation payload should summarize, not duplicate full raw provenance.
+- Drivers and limitations should be understandable without exposing private raw evidence unnecessarily.
+- The payload should stay stable enough for UI rendering even as the reason list evolves.
+- Contribution objects should be additive and machine-usable.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/node-observation-schema.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/node-observation-schema.md
@@ -1,0 +1,110 @@
+---
+title: Node Observation Schema
+description: Canonical evidence packet and normalized observation model used between hardware nodes and the ingest service.
+section: data-model
+audience: [builder, researcher]
+order: 2
+status: stable
+schema_file: node-observation.schema.json
+example_file: node-observation.example.json
+---
+
+## Purpose
+
+Define the canonical evidence packet and normalized observation model used between hardware nodes and the ingest service.
+
+## First supported schema version
+
+- `rhi.bench-air.v1`
+
+This version covers the bench-air-node MVP and establishes the minimum structure future node schemas should preserve:
+- explicit schema versioning
+- stable node identity
+- observation timestamp
+- sensor presence reporting
+- health telemetry
+- provenance-friendly raw payload retention
+
+## Raw packet contract
+
+Required top-level fields:
+- `schema_version`
+- `node_id`
+- `observed_at`
+- `firmware_version`
+- `location_mode`
+- `sensors`
+- `health`
+
+Optional top-level fields:
+- `derived`
+- `sequence`
+- `transport`
+- `notes`
+
+Example packet:
+
+```json
+{
+  "schema_version": "rhi.bench-air.v1",
+  "node_id": "bench-air-01",
+  "observed_at": "2026-03-30T19:45:00Z",
+  "firmware_version": "0.1.0",
+  "location_mode": "indoor",
+  "sensors": {
+    "sht45": {
+      "present": true,
+      "temperature_c": 23.4,
+      "relative_humidity_pct": 41.8
+    },
+    "bme680": {
+      "present": true,
+      "temperature_c": 24.1,
+      "relative_humidity_pct": 40.9,
+      "pressure_hpa": 1012.6,
+      "gas_resistance_ohm": 145230
+    }
+  },
+  "health": {
+    "uptime_s": 1820,
+    "wifi_connected": true,
+    "free_heap_bytes": 214332,
+    "read_failures_total": 0,
+    "last_error": null
+  }
+}
+```
+
+## Normalized observation model
+
+Suggested canonical shape after ingest:
+
+```json
+{
+  "observation_id": "obs_01HT...",
+  "node_id": "bench-air-01",
+  "parcel_id": "parcel_123",
+  "observed_at": "2026-03-30T19:45:00Z",
+  "ingested_at": "2026-03-30T19:45:02Z",
+  "observation_type": "air.node.snapshot",
+  "values": {
+    "temperature_c_primary": 23.4,
+    "relative_humidity_pct_primary": 41.8,
+    "pressure_hpa": 1012.6,
+    "gas_resistance_ohm": 145230
+  },
+  "provenance": {
+    "source_kind": "homeowner_node",
+    "schema_version": "rhi.bench-air.v1",
+    "firmware_version": "0.1.0",
+    "raw_packet_ref": "rawpkt_01HT..."
+  }
+}
+```
+
+## Design rules
+
+- Raw evidence should remain recoverable after normalization.
+- Ingest should not convert observations directly into parcel-state outputs.
+- Missing sensor values must be explicit, not silently omitted because of read errors.
+- Future schemas should extend by version, not by changing the meaning of existing fields in place.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/node-registry-schema.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/node-registry-schema.md
@@ -1,0 +1,77 @@
+---
+title: Node Registry Schema
+description: Parcel-scoped registry binding physical nodes to one parcel, one software stack, and one homeowner-facing product surface.
+section: data-model
+audience: [builder, researcher]
+order: 3
+status: stable
+schema_file: node-registry.schema.json
+example_file: node-registry.example.json
+---
+
+## Purpose
+
+Define the parcel-scoped registry object that binds one or more physical nodes to one parcel, one software stack, and one homeowner-facing product surface.
+
+## Core fields
+
+- `updated_at`
+- `parcel_id`
+- `nodes`
+
+Each node entry includes:
+
+- `node_id`
+- `node_class`
+- `hardware_family`
+- `schema_version`
+- `observation_family`
+- `location_mode`
+- `install_role`
+- `transport_mode`
+- `power_mode`
+- `calibration_state`
+- `installed_at`
+- `last_seen_at`
+- `enabled`
+
+Optional fields: `firmware_version`, `privacy_mode`
+
+## Minimum object
+
+```json
+{
+  "updated_at": "2026-04-01T18:00:00Z",
+  "parcel_id": "parcel_123",
+  "nodes": [
+    {
+      "node_id": "bench-air-01",
+      "node_class": "indoor_air",
+      "hardware_family": "bench-air-node",
+      "schema_version": "rhi.bench-air.v1",
+      "observation_family": "air.node.snapshot",
+      "location_mode": "indoor",
+      "install_role": "indoor_reference",
+      "transport_mode": "https_push",
+      "power_mode": "usb_c_mains",
+      "calibration_state": "verified",
+      "installed_at": "2026-03-29T18:00:00Z",
+      "last_seen_at": "2026-04-01T17:58:00Z",
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Design rules
+
+- There is one node registry per parcel, not one registry per node.
+- `parcel_id` lives at the registry layer so hardware packets do not need to carry exact parcel identity.
+- `node_id` must be unique within the registry and should remain stable across firmware updates.
+- `hardware_family` describes the physical build lineage, while `schema_version` describes the emitted packet contract.
+- `install_role` captures why the node exists in the parcel system, not just where it is mounted.
+- `enabled: false` means the node remains historically known but should not be treated as active evidence.
+
+## Why this object matters
+
+The integrated parcel design depends on multiple specialized nodes behaving like one system. The node registry is the bridge between hardware installation, ingest authorization, calibration tracking, inference observability assumptions, and operator troubleshooting.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/overview.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/overview.md
@@ -1,0 +1,37 @@
+---
+title: Data Model Overview
+description: Canonical definitions for parcels, nodes, observations, states, permissions, provenance, and support objects.
+section: data-model
+audience: [builder, researcher, contributor]
+order: 0
+status: stable
+---
+
+## Purpose
+
+Canonical definitions for parcels, nodes, observations, states, permissions, provenance, and later-stage support objects.
+
+## Minimum contents
+
+- packet schemas from hardware and external feeds
+- normalized observation objects
+- parcel-state outputs
+- provenance and freshness fields
+- identity and permission linkages
+
+## Current status
+
+The current center of gravity remains the `v1` observation, parcel-context, and parcel-state contracts.
+
+`v1.5` adds separate support objects for:
+- house state
+- house capability
+- control compatibility
+- intervention events
+- verification outcomes
+
+Those support objects should not be mistaken for a breaking change to the current parcel-state contract.
+
+## Machine-readable artifacts
+
+Schemas and examples are available in the repository under `schemas/` and `examples/` directories within the data-model folder.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/parcel-state-schema.md
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/content/docs/data-model/parcel-state-schema.md
@@ -1,0 +1,138 @@
+---
+title: Parcel State Schema
+description: Canonical parcel-level output produced by the inference engine for homeowner-facing use and downstream mapping.
+section: data-model
+audience: [builder, researcher]
+order: 1
+status: stable
+schema_file: parcel-state.schema.json
+example_file: parcel-state.example.json
+---
+
+## Purpose
+
+Define the canonical parcel-level output produced by the inference engine for homeowner-facing use and downstream mapping.
+
+## Version boundary
+
+This schema represents the current `v1` parcel sensing and inference baseline.
+
+It stays stable through `v1.5` so the repo can add house-state, capability, compatibility, intervention, and verification objects without forcing a breaking parcel-state change.
+
+Narrative aliases such as `stay_safe`, `enter_safe`, `escape_safe`, and `asset_safe` may appear in planning documents, but the current repo keeps the existing field names through at least `v2`.
+
+## Core status fields
+
+- `shelter_status`
+- `reentry_status`
+- `egress_status`
+- `asset_risk_status`
+- `confidence`
+- `evidence_mode`
+- `inference_basis`
+- `reasons`
+
+Suggested initial enum for status fields:
+- `safe`
+- `caution`
+- `unsafe`
+- `unknown`
+
+Suggested initial enum for `evidence_mode`:
+- `local_only`
+- `local_plus_public`
+- `public_only`
+- `insufficient`
+
+Suggested initial enum for `inference_basis`:
+- `local_only`
+- `local_plus_shared`
+- `local_plus_public`
+- `local_plus_shared_plus_public`
+- `public_only`
+- `shared_only`
+- `shared_plus_public`
+- `insufficient`
+
+## Supporting values
+
+- `smoke_probability`
+- `flood_probability`
+- `heat_probability`
+- `explanation_payload`
+- `freshness`
+- `provenance_summary`
+
+## Minimum parcel-state object
+
+```json
+{
+  "parcel_id": "parcel_123",
+  "computed_at": "2026-03-30T19:46:00Z",
+  "shelter_status": "unknown",
+  "reentry_status": "unknown",
+  "egress_status": "unknown",
+  "asset_risk_status": "unknown",
+  "confidence": 0.30,
+  "evidence_mode": "insufficient",
+  "inference_basis": "insufficient",
+  "explanation_payload": {
+    "headline": "Estimate uses limited local evidence with low parcel certainty.",
+    "basis": {
+      "evidence_mode": "insufficient",
+      "inference_basis": "insufficient",
+      "confidence_band": "low"
+    },
+    "drivers": [
+      "Indoor gas-resistance trend shows a moderate change."
+    ],
+    "limitations": [
+      "The local node is indoor and does not represent parcel-wide outdoor conditions.",
+      "No flood-capable local sensor or public flood context is present."
+    ]
+  },
+  "reasons": [
+    "Local gas-resistance trend shows a moderate change, but it is not a direct smoke concentration measurement.",
+    "Current local evidence comes from an indoor node and does not directly represent parcel-wide outdoor conditions."
+  ],
+  "hazards": {
+    "smoke_probability": 0.12,
+    "flood_probability": 0.00,
+    "heat_probability": 0.02
+  },
+  "freshness": {
+    "latest_observation_at": "2026-03-30T19:45:00Z",
+    "seconds_since_latest": 60,
+    "stale": false
+  },
+  "provenance_summary": {
+    "observation_count": 1,
+    "source_modes": ["homeowner_node"],
+    "observation_refs": ["obs_example_0001"]
+  }
+}
+```
+
+## Field notes
+
+- `confidence` -- Numeric confidence in the parcel-state assessment, not a claim of physical certainty.
+- `reasons` -- Human-readable explanation fragments suitable for UI and audit logs.
+- `inference_basis` -- Machine-facing evidence-composition field that distinguishes mixed-source combinations more precisely than the homeowner-facing `evidence_mode`.
+- `explanation_payload` -- Structured explanation object for UI composition, notification drafting, and audit support.
+- `hazards` -- Hazard-specific supporting scores used to derive the status fields.
+- `freshness` -- Explicit recency information so old evidence does not look current.
+- `provenance_summary` -- Short reference block pointing to the evidence used for the decision.
+
+## Design rules
+
+- Parcel-state outputs must remain understandable to a homeowner.
+- Status labels should frame conditions and risk, not imply emergency authorization or guarantees.
+- Confidence should fall when evidence is sparse, stale, or conflicting.
+- Inference should produce `unknown` when evidence quality is too weak for a stronger claim.
+- Every parcel-state snapshot should be traceable back to source observations.
+
+## Planned follow-on additions
+
+`v1.5`: keep parcel-state stable; store house-state, capability, compatibility, intervention, and verification data as separate support objects.
+
+`v2` and later may add optional presentation summaries such as bounded recommendations, actionability notes, and recommendation or verification references.

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/data/docs-nav.ts
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/data/docs-nav.ts
@@ -1,0 +1,79 @@
+export interface NavItem {
+  label: string;
+  href: string;
+}
+
+export interface NavSection {
+  title: string;
+  slug: string;
+  items: NavItem[];
+}
+
+export const docsNav: NavSection[] = [
+  {
+    title: "Getting Started",
+    slug: "getting-started",
+    items: [
+      { label: "Overview", href: "/docs/getting-started/overview.html" }
+    ]
+  },
+  {
+    title: "Data Model",
+    slug: "data-model",
+    items: [
+      { label: "Overview", href: "/docs/data-model/overview.html" },
+      { label: "Parcel State", href: "/docs/data-model/parcel-state-schema.html" },
+      { label: "Node Observation", href: "/docs/data-model/node-observation-schema.html" },
+      { label: "Node Registry", href: "/docs/data-model/node-registry-schema.html" },
+      { label: "Parcel Context", href: "/docs/data-model/parcel-context-schema.html" },
+      { label: "Public Context", href: "/docs/data-model/public-context-schema.html" },
+      { label: "House State", href: "/docs/data-model/house-state-schema.html" },
+      { label: "House Capability", href: "/docs/data-model/house-capability-schema.html" },
+      { label: "Control Compatibility", href: "/docs/data-model/control-compatibility-schema.html" },
+      { label: "Intervention Event", href: "/docs/data-model/intervention-event-schema.html" },
+      { label: "Verification Outcome", href: "/docs/data-model/verification-outcome-schema.html" },
+      { label: "Explanation Payload", href: "/docs/data-model/explanation-payload-schema.html" },
+      { label: "Evidence Summary", href: "/docs/data-model/evidence-summary-schema.html" },
+      { label: "Evidence Mode", href: "/docs/data-model/evidence-mode-and-observability.html" }
+    ]
+  },
+  {
+    title: "Privacy & Governance",
+    slug: "privacy",
+    items: [
+      { label: "Sharing Settings", href: "/docs/data-model/sharing-settings-schema.html" },
+      { label: "Consent Record", href: "/docs/data-model/consent-record-schema.html" },
+      { label: "Rights Request", href: "/docs/data-model/rights-request-schema.html" },
+      { label: "Neighborhood Signal", href: "/docs/data-model/shared-neighborhood-signal-schema.html" },
+      { label: "Operator Access", href: "/docs/data-model/operator-access-event-schema.html" },
+      { label: "Export Bundle", href: "/docs/data-model/export-bundle-schema.html" },
+      { label: "Retention Report", href: "/docs/data-model/retention-cleanup-report-schema.html" },
+      { label: "Sharing Store", href: "/docs/data-model/sharing-store-schema.html" }
+    ]
+  },
+  {
+    title: "Hardware",
+    slug: "hardware",
+    items: []
+  },
+  {
+    title: "System Overview",
+    slug: "system",
+    items: []
+  },
+  {
+    title: "Build Guides",
+    slug: "build-guides",
+    items: []
+  },
+  {
+    title: "Pilot Playbooks",
+    slug: "pilot-playbooks",
+    items: []
+  },
+  {
+    title: "Legal",
+    slug: "legal",
+    items: []
+  }
+];

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/data/faqs.ts
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/data/faqs.ts
@@ -1,0 +1,37 @@
+export const faqs = [
+  {
+    question: "Is all project data public now?",
+    answer:
+      "No. The project-controlled v1 dataset may be intentionally public when it is explicitly designated, licensed, and documented. Future participant-contributed parcel-linked data still remains private by default."
+  },
+  {
+    question: "What is actually public in this release?",
+    answer:
+      "Approved governance, privacy, licensing, release, and selected technical materials are public now under asset-specific terms. Not every repo file is automatically a public release asset."
+  },
+  {
+    question: "Is this emergency guidance or a replacement for official alerts?",
+    answer:
+      "No. Parcel-state outputs are estimates or inferences. Official alerts, on-scene conditions, and personal judgment still matter."
+  },
+  {
+    question: "Does open source here also mean open trademark use?",
+    answer:
+      "No. Copyright licenses, data terms, and trademark permissions are separate questions. Use the attached notices and policy docs rather than assuming broad brand rights."
+  },
+  {
+    question: "Can I build the current reference stack?",
+    answer:
+      "Yes, there is a current reference path. Start with the operator quickstart, the checked-in schemas and examples, and the implementation status matrix before assuming every planned surface is already complete."
+  },
+  {
+    question: "Is a patent required for this release?",
+    answer:
+      "No. The current repo posture is an open release with deliberate public disclosure, not a patent-first launch requirement."
+  },
+  {
+    question: "Where should I start if I want to contribute?",
+    answer:
+      "Start with the contribution policy, the public release scope, the dataset release policy, and the release notes. That combination tells you what is public, what is not, and how not to break the boundary."
+  }
+];

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/layouts/DocsLayout.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/layouts/DocsLayout.astro
@@ -1,0 +1,43 @@
+---
+import SiteLayout from "./SiteLayout.astro";
+import DocsSidebar from "../components/DocsSidebar.astro";
+import Breadcrumbs from "../components/Breadcrumbs.astro";
+
+const {
+  title,
+  description,
+  headings = []
+} = Astro.props;
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+const tocHeadings = (headings as Heading[]).filter((h) => h.depth >= 2 && h.depth <= 3);
+---
+
+<SiteLayout title={title} description={description}>
+  <div class="docs-grid" slot="default">
+    <DocsSidebar />
+    <article class="docs-content">
+      <Breadcrumbs />
+      <slot />
+    </article>
+    {tocHeadings.length > 2 && (
+      <aside class="docs-toc" aria-label="On this page">
+        <p class="docs-toc-title">On this page</p>
+        <nav>
+          <ul>
+            {tocHeadings.map((h) => (
+              <li class:list={[`toc-depth-${h.depth}`]}>
+                <a href={`#${h.slug}`}>{h.text}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+    )}
+  </div>
+</SiteLayout>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/layouts/SiteLayout.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/layouts/SiteLayout.astro
@@ -1,14 +1,19 @@
 ---
 import "../styles/global.css";
+import { ViewTransitions } from "astro:transitions";
+import SiteNav from "../components/SiteNav.astro";
+import SearchDialog from "../components/SearchDialog.astro";
 
 const {
   title,
   description,
   ogTitle = title,
-  ogDescription = description
+  ogDescription = description,
+  hideNav = false
 } = Astro.props;
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url);
+const allowIndexing = import.meta.env.PUBLIC_ALLOW_INDEXING === "true";
 ---
 
 <!DOCTYPE html>
@@ -18,7 +23,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url);
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{title}</title>
     <meta name="description" content={description}>
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content={allowIndexing ? "index, follow" : "noindex, nofollow"}>
     <link rel="canonical" href={canonicalUrl.href}>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta property="og:title" content={ogTitle}>
@@ -26,9 +31,42 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url);
     <meta property="og:type" content="website">
     <meta property="og:url" content={canonicalUrl.href}>
     <meta name="twitter:card" content="summary">
+    <ViewTransitions />
+    <script is:inline>
+      (function() {
+        var t = localStorage.getItem("theme");
+        if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+      })();
+    </script>
+    <script is:inline>
+      document.addEventListener('astro:page-load', function() {
+        var btn = document.getElementById('theme-toggle');
+        if (!btn) return;
+        function updatePressed() {
+          var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+          btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        }
+        updatePressed();
+        btn.addEventListener('click', function() {
+          var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+          if (isDark) {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.setItem('theme', 'light');
+          } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            localStorage.setItem('theme', 'dark');
+          }
+          updatePressed();
+        });
+      });
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
+    {!hideNav && <SiteNav />}
+    <SearchDialog />
     <div class="page-shell">
       <slot name="hero" />
       <main id="main">

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/docs/[...slug].astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/docs/[...slug].astro
@@ -1,0 +1,27 @@
+---
+import { getCollection, render } from "astro:content";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+export async function getStaticPaths() {
+  const docs = await getCollection("docs", ({ data }) => !data.draft);
+  return docs.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry }
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+---
+
+<DocsLayout
+  title={`${entry.data.title} - RHI Docs`}
+  description={entry.data.description || entry.data.title}
+  headings={headings}
+>
+  <h1>{entry.data.title}</h1>
+  {entry.data.description && (
+    <p class="docs-content-lede">{entry.data.description}</p>
+  )}
+  <Content />
+</DocsLayout>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/docs/index.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/docs/index.astro
@@ -1,0 +1,33 @@
+---
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import { docsNav } from "../../data/docs-nav";
+---
+
+<DocsLayout
+  title="Documentation - RHI"
+  description="Browse the Resilient Home Intelligence documentation: data model schemas, privacy governance, hardware guides, and system architecture."
+>
+  <h1>Documentation</h1>
+  <p class="docs-content-lede">
+    Canonical definitions for the Resilient Home Intelligence data model, privacy governance,
+    hardware families, and system architecture.
+  </p>
+
+  <div class="docs-hub-grid">
+    {docsNav.filter((s) => s.items.length > 0).map((section) => (
+      <article class="docs-hub-card">
+        <p class="kicker">{section.title}</p>
+        <ul class="docs-hub-links">
+          {section.items.slice(0, 5).map((item) => (
+            <li><a href={item.href}>{item.label}</a></li>
+          ))}
+          {section.items.length > 5 && (
+            <li class="docs-hub-more">
+              +{section.items.length - 5} more
+            </li>
+          )}
+        </ul>
+      </article>
+    ))}
+  </div>
+</DocsLayout>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/faq.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/faq.astro
@@ -1,7 +1,9 @@
 ---
 import SiteLayout from "../layouts/SiteLayout.astro";
 import PageHero from "../components/PageHero.astro";
+import Accordion from "../components/Accordion.astro";
 import { repoLinks } from "../lib/repo-links";
+import { faqs } from "../data/faqs";
 
 const pageLinks = [
   { href: "index.html", label: "Main release" },
@@ -14,44 +16,6 @@ const heroAsideItems = [
   "Is all data public?",
   "Is this emergency guidance?",
   "How do I build or contribute?"
-];
-
-const faqs = [
-  {
-    question: "Is all project data public now?",
-    answer:
-      "No. The project-controlled v1 dataset may be intentionally public when it is explicitly designated, licensed, and documented. Future participant-contributed parcel-linked data still remains private by default."
-  },
-  {
-    question: "What is actually public in this release?",
-    answer:
-      "Approved governance, privacy, licensing, release, and selected technical materials are public now under asset-specific terms. Not every repo file is automatically a public release asset."
-  },
-  {
-    question: "Is this emergency guidance or a replacement for official alerts?",
-    answer:
-      "No. Parcel-state outputs are estimates or inferences. Official alerts, on-scene conditions, and personal judgment still matter."
-  },
-  {
-    question: "Does open source here also mean open trademark use?",
-    answer:
-      "No. Copyright licenses, data terms, and trademark permissions are separate questions. Use the attached notices and policy docs rather than assuming broad brand rights."
-  },
-  {
-    question: "Can I build the current reference stack?",
-    answer:
-      "Yes, there is a current reference path. Start with the operator quickstart, the checked-in schemas and examples, and the implementation status matrix before assuming every planned surface is already complete."
-  },
-  {
-    question: "Is a patent required for this release?",
-    answer:
-      "No. The current repo posture is an open release with deliberate public disclosure, not a patent-first launch requirement."
-  },
-  {
-    question: "Where should I start if I want to contribute?",
-    answer:
-      "Start with the contribution policy, the public release scope, the dataset release policy, and the release notes. That combination tells you what is public, what is not, and how not to break the boundary."
-  }
 ];
 
 const readNextLinks = [
@@ -88,11 +52,10 @@ const readNextLinks = [
     <p class="section-label">FAQ</p>
     <h2>Common questions</h2>
     <div class="faq-list">
-      {faqs.map((item) => (
-        <article class="faq-item">
-          <h3>{item.question}</h3>
+      {faqs.map((item, i) => (
+        <Accordion title={item.question} open={i === 0}>
           <p>{item.answer}</p>
-        </article>
+        </Accordion>
       ))}
     </div>
   </section>

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/index.astro
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/pages/index.astro
@@ -233,10 +233,11 @@ const footerLinks = [
 >
   <Fragment slot="hero">
     <PageHero
-      eyebrow="April 14, 2026 Open Release"
+      eyebrow="v1 Open Release"
       title="Homeowner-owned environmental sensing, built parcel first."
       lede="Resilient Home Intelligence is a modular, homeowner-centered effort to build parcel-level environmental awareness for smoke, flooding and runoff, and heat without forcing homeowners to surrender raw data to a centralized platform."
       tagline="Private by default. Shared by choice. Open release with clear boundaries."
+      versionBar="April 14, 2026 Open Release"
       meta={heroMeta}
       pageLinks={pageLinks}
       actions={heroActions}

--- a/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/styles/global.css
+++ b/programs/resilient-home-intelligence/docs/release/2026-04-14/site/src/styles/global.css
@@ -20,6 +20,222 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 4.5rem;
+}
+
+/* ── Site navigation ── */
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--paper);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+}
+
+.site-nav-inner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  height: 3.5rem;
+}
+
+.site-nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  text-decoration: none;
+  color: var(--ink);
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin-right: auto;
+}
+
+.site-nav-logo {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.site-nav-name {
+  font-family: "Courier New", monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.site-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.site-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 0.92rem;
+  transition: color 0.15s, background 0.15s;
+}
+
+.site-nav-link:hover {
+  color: var(--ink);
+  background: rgba(232, 215, 183, 0.4);
+}
+
+.site-nav-link.active {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.site-nav-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.site-nav-link--external svg {
+  opacity: 0.5;
+}
+
+.site-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+
+.site-nav-search-btn,
+.site-nav-theme-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.site-nav-search-btn {
+  width: auto;
+  padding: 0 0.65rem;
+}
+
+.site-nav-search-btn:hover,
+.site-nav-theme-btn:hover {
+  color: var(--ink);
+  background: rgba(232, 215, 183, 0.4);
+  border-color: rgba(63, 49, 30, 0.28);
+}
+
+.site-nav-search-btn:focus-visible,
+.site-nav-theme-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.site-nav-search-hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.site-nav-search-hint kbd {
+  font-family: inherit;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  border: 1px solid var(--line);
+  background: var(--paper-strong);
+}
+
+/* Theme toggle icon states */
+[data-theme="dark"] .icon-sun { display: none; }
+[data-theme="dark"] .icon-moon { display: inline-flex; }
+:root:not([data-theme="dark"]) .icon-moon { display: none; }
+:root:not([data-theme="dark"]) .icon-sun { display: inline-flex; }
+
+/* Mobile nav */
+.site-nav-mobile {
+  display: none;
+}
+
+.site-nav-hamburger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--muted);
+  list-style: none;
+}
+
+.site-nav-hamburger::-webkit-details-marker {
+  display: none;
+}
+
+.site-nav-hamburger:hover {
+  color: var(--ink);
+  background: rgba(232, 215, 183, 0.4);
+}
+
+.site-nav-drawer {
+  position: absolute;
+  top: 3.5rem;
+  left: 0;
+  right: 0;
+  background: var(--paper-strong);
+  border-bottom: 1px solid var(--line);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: var(--shadow);
+}
+
+.site-nav-drawer-link {
+  display: block;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 1rem;
+  transition: background 0.15s;
+}
+
+.site-nav-drawer-link:hover,
+.site-nav-drawer-link.active {
+  background: rgba(232, 215, 183, 0.45);
+}
+
+.site-nav-drawer-link.active {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+@media (max-width: 760px) {
+  .site-nav-links {
+    display: none;
+  }
+  .site-nav-mobile {
+    display: block;
+  }
+  .site-nav-search-hint {
+    display: none;
+  }
 }
 
 body {
@@ -62,6 +278,59 @@ body {
   backdrop-filter: blur(10px);
 }
 
+/* ── Version bar (above hero) ── */
+
+.version-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.65rem 1.2rem;
+  margin-bottom: 0.5rem;
+  border-radius: 999px;
+  background: var(--forest);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.88rem;
+}
+
+.version-bar-label {
+  font-family: "Courier New", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.version-bar-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.version-bar-meta span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  font-size: 0.8rem;
+}
+
+/* Hero image support */
+.hero-image-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+}
+
 .hero {
   padding: 3rem;
   border-radius: var(--radius-lg);
@@ -96,14 +365,14 @@ body {
   color: var(--forest);
 }
 
-.top-nav {
+.section-nav {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.65rem;
 }
 
-.top-nav a {
+.section-nav a {
   display: inline-flex;
   align-items: center;
   min-height: 2.35rem;
@@ -117,12 +386,12 @@ body {
   transition: background 0.15s, border-color 0.15s;
 }
 
-.top-nav a:hover {
+.section-nav a:hover {
   background: rgba(232, 215, 183, 0.55);
   border-color: rgba(63, 49, 30, 0.32);
 }
 
-.top-nav a:focus-visible {
+.section-nav a:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -502,6 +771,830 @@ main {
   line-height: 1.7;
 }
 
+/* ── Docs layout ── */
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 200px;
+  gap: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.docs-sidebar {
+  position: sticky;
+  top: 4.5rem;
+  max-height: calc(100vh - 5rem);
+  overflow-y: auto;
+  padding-right: 1rem;
+}
+
+.docs-sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.docs-sidebar-heading {
+  display: block;
+  font-family: "Courier New", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--forest);
+  text-decoration: none;
+  padding: 0.5rem 0.6rem;
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+}
+
+.docs-sidebar-section {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-sidebar-section-title {
+  display: block;
+  font-family: "Courier New", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0.55rem 0.6rem 0.35rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.docs-sidebar-section-title::-webkit-details-marker {
+  display: none;
+}
+
+.docs-sidebar-section-title::before {
+  content: ">";
+  display: inline-block;
+  width: 1rem;
+  font-size: 0.7rem;
+  transition: transform 0.15s;
+}
+
+details[open] > .docs-sidebar-section-title::before {
+  transform: rotate(90deg);
+}
+
+.docs-sidebar-section-empty {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.docs-sidebar-section-empty::before {
+  content: "";
+  width: 0;
+}
+
+.docs-sidebar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.35rem;
+}
+
+.docs-sidebar-link {
+  display: block;
+  padding: 0.35rem 0.6rem 0.35rem 1.6rem;
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 0.9rem;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+  line-height: 1.45;
+}
+
+.docs-sidebar-link:hover {
+  color: var(--ink);
+  background: rgba(232, 215, 183, 0.35);
+}
+
+.docs-sidebar-link.active {
+  color: var(--accent);
+  font-weight: 700;
+  background: rgba(157, 67, 21, 0.07);
+}
+
+.docs-sidebar-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Docs content area */
+.docs-content {
+  min-width: 0;
+  max-width: 75ch;
+}
+
+.docs-content h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.docs-content h2 {
+  margin: 2rem 0 0.75rem;
+  font-size: 1.4rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-content h3 {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.docs-content p {
+  color: var(--muted);
+  line-height: 1.75;
+  margin: 0 0 1rem;
+}
+
+.docs-content ul,
+.docs-content ol {
+  padding-left: 1.4rem;
+  color: var(--muted);
+  line-height: 1.75;
+  margin: 0 0 1rem;
+}
+
+.docs-content li + li {
+  margin-top: 0.3rem;
+}
+
+.docs-content code {
+  font-family: "Courier New", monospace;
+  font-size: 0.9em;
+  padding: 0.15rem 0.35rem;
+  border-radius: 5px;
+  background: rgba(232, 215, 183, 0.35);
+  border: 1px solid var(--line);
+}
+
+.docs-content pre {
+  margin: 0 0 1.25rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-md);
+  background: var(--paper-strong);
+  border: 1px solid var(--line);
+  overflow-x: auto;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.docs-content pre code {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: inherit;
+}
+
+.docs-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+}
+
+.docs-content a:hover {
+  color: var(--accent-soft);
+}
+
+.docs-content a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.docs-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 1.25rem;
+  font-size: 0.92rem;
+}
+
+.docs-content th,
+.docs-content td {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--line);
+  text-align: left;
+}
+
+.docs-content th {
+  background: rgba(232, 215, 183, 0.25);
+  font-weight: 700;
+}
+
+.docs-content blockquote {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  border-left: 4px solid var(--accent-soft);
+  background: rgba(232, 215, 183, 0.15);
+  border-radius: 0 8px 8px 0;
+  color: var(--muted);
+}
+
+.docs-content blockquote p {
+  margin: 0;
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+  margin-bottom: 1.25rem;
+}
+
+.breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0;
+}
+
+.breadcrumbs li {
+  display: flex;
+  align-items: center;
+  font-family: "Courier New", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.breadcrumbs a {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.breadcrumbs a:hover {
+  color: var(--accent);
+}
+
+.breadcrumbs [aria-current="page"] {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.breadcrumb-sep {
+  margin: 0 0.4rem;
+  color: var(--line);
+}
+
+/* Table of contents */
+.docs-toc {
+  position: sticky;
+  top: 4.5rem;
+  max-height: calc(100vh - 5rem);
+  overflow-y: auto;
+  padding-left: 1rem;
+  border-left: 1px solid var(--line);
+}
+
+.docs-toc-title {
+  font-family: "Courier New", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.docs-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-toc li {
+  margin: 0;
+}
+
+.docs-toc a {
+  display: block;
+  padding: 0.25rem 0;
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+  transition: color 0.15s;
+}
+
+.docs-toc a:hover {
+  color: var(--accent);
+}
+
+.docs-toc .toc-depth-3 a {
+  padding-left: 1rem;
+  font-size: 0.8rem;
+}
+
+.docs-toc .toc-active a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* Docs hub index */
+.docs-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.docs-hub-card {
+  padding: 1.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: rgba(255, 248, 239, 0.74);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.docs-hub-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 60px rgba(40, 24, 5, 0.14);
+}
+
+.docs-hub-links {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.docs-hub-links li {
+  margin: 0;
+}
+
+.docs-hub-links a {
+  display: block;
+  padding: 0.3rem 0;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: color 0.15s;
+}
+
+.docs-hub-links a:hover {
+  color: var(--accent-soft);
+  text-decoration: underline;
+}
+
+.docs-hub-more {
+  padding: 0.3rem 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.docs-content-lede {
+  font-size: 1.1rem;
+  color: var(--muted);
+  line-height: 1.7;
+  margin: 0 0 1.5rem;
+  max-width: 60ch;
+}
+
+/* ── Schema viewer ── */
+
+.schema-viewer {
+  margin: 1rem 0 1.5rem;
+}
+
+.schema-tabs {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-template-rows: auto 1fr;
+}
+
+.schema-tab-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.schema-tab-label {
+  grid-row: 1;
+  padding: 0.5rem 1rem;
+  font-family: "Courier New", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  border-bottom: none;
+  background: transparent;
+  color: var(--muted);
+  border-radius: 8px 8px 0 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.schema-tab-input:checked + .schema-tab-label {
+  background: var(--paper-strong);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.schema-tab-label:hover {
+  color: var(--ink);
+}
+
+.schema-tab-panel {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  display: none;
+}
+
+.schema-tab-input:nth-of-type(1):checked ~ .schema-tab-panel[data-tab="schema"] {
+  display: block;
+}
+
+.schema-tab-input:nth-of-type(2):checked ~ .schema-tab-panel[data-tab="example"] {
+  display: block;
+}
+
+.schema-tab-panel pre {
+  margin: 0;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  border-top: none;
+}
+
+.schema-details {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper-strong);
+}
+
+.schema-details-summary {
+  padding: 0.65rem 1rem;
+  font-family: "Courier New", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  color: var(--muted);
+  list-style: none;
+}
+
+.schema-details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.schema-details[open] .schema-details-summary {
+  border-bottom: 1px solid var(--line);
+}
+
+.schema-details pre {
+  margin: 0;
+  border: none;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+/* ── Accordion ── */
+
+.accordion {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 248, 239, 0.72);
+  transition: box-shadow 0.15s;
+}
+
+.accordion + .accordion {
+  margin-top: 0.65rem;
+}
+
+.accordion[open] {
+  box-shadow: 0 4px 20px rgba(40, 24, 5, 0.08);
+}
+
+.accordion-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.2rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-title {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.accordion-chevron {
+  color: var(--muted);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+
+.accordion[open] .accordion-chevron {
+  transform: rotate(180deg);
+}
+
+.accordion-content {
+  padding: 0 1.2rem 1.1rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.accordion-content p {
+  margin: 0;
+}
+
+/* ── Search dialog ── */
+
+.search-dialog {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  max-width: 600px;
+  margin: 8vh auto auto;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--paper-strong);
+  box-shadow: 0 30px 80px rgba(40, 24, 5, 0.25);
+  max-height: 70vh;
+  overflow: hidden;
+}
+
+.search-dialog::backdrop {
+  background: rgba(31, 27, 22, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.search-dialog-inner {
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+.search-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.search-dialog-title {
+  font-family: "Courier New", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.search-dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.search-dialog-close:hover {
+  color: var(--ink);
+  background: rgba(232, 215, 183, 0.4);
+}
+
+#pagefind-container {
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+/* ── Status badge ── */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-family: "Courier New", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--badge-color, var(--muted));
+  background: color-mix(in srgb, var(--badge-color, var(--muted)) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--badge-color, var(--muted)) 25%, transparent);
+}
+
+.status-badge-version {
+  font-weight: 400;
+  opacity: 0.8;
+}
+
+/* ── Dark mode ── */
+
+[data-theme="dark"] {
+  --bg: #1a1714;
+  --paper: rgba(30, 27, 22, 0.92);
+  --paper-strong: #252118;
+  --ink: #e8e0d4;
+  --muted: #a89e90;
+  --line: rgba(200, 180, 150, 0.16);
+  --accent: #d36c2d;
+  --accent-soft: #e8944a;
+  --forest: #6aad8c;
+  --sand: #3d3528;
+  --shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="dark"] body {
+  background:
+    radial-gradient(circle at top left, rgba(211, 108, 45, 0.12), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(48, 82, 66, 0.10), transparent 24%),
+    linear-gradient(180deg, #1a1714 0%, #141210 100%);
+}
+
+[data-theme="dark"] .hero::after {
+  background: radial-gradient(circle, rgba(211, 108, 45, 0.10), transparent 68%);
+}
+
+[data-theme="dark"] .status-card,
+[data-theme="dark"] .dataset-card,
+[data-theme="dark"] .action-card,
+[data-theme="dark"] .pathway-card,
+[data-theme="dark"] .timeline-item,
+[data-theme="dark"] .faq-item,
+[data-theme="dark"] .docs-hub-card {
+  background: rgba(37, 33, 24, 0.8);
+}
+
+[data-theme="dark"] .notice-panel,
+[data-theme="dark"] .panel-accent {
+  background:
+    linear-gradient(135deg, rgba(61, 53, 40, 0.5), rgba(30, 27, 22, 0.92)),
+    var(--paper-strong);
+}
+
+[data-theme="dark"] .section-nav a,
+[data-theme="dark"] .link-groups a {
+  background: rgba(37, 33, 24, 0.8);
+}
+
+[data-theme="dark"] .section-nav a:hover,
+[data-theme="dark"] .link-groups a:hover {
+  background: rgba(61, 53, 40, 0.8);
+}
+
+[data-theme="dark"] .version-bar {
+  background: #1a3d2d;
+}
+
+[data-theme="dark"] .hero-aside {
+  background: rgba(37, 33, 24, 0.9);
+}
+
+[data-theme="dark"] .meta-strip span {
+  background: rgba(37, 33, 24, 0.8);
+}
+
+[data-theme="dark"] .chip {
+  background: rgba(106, 173, 140, 0.12);
+}
+
+[data-theme="dark"] .accordion {
+  background: rgba(37, 33, 24, 0.72);
+}
+
+[data-theme="dark"] .search-dialog {
+  background: #1e1b16;
+}
+
+[data-theme="dark"] .search-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+[data-theme="dark"] .docs-content code {
+  background: rgba(61, 53, 40, 0.5);
+}
+
+[data-theme="dark"] .docs-content pre {
+  background: #1e1b16;
+}
+
+[data-theme="dark"] .docs-content blockquote {
+  background: rgba(61, 53, 40, 0.25);
+}
+
+[data-theme="dark"] .docs-content th {
+  background: rgba(61, 53, 40, 0.4);
+}
+
+/* ── Interaction improvements ── */
+
+:target {
+  scroll-margin-top: 5rem;
+  animation: target-flash 1.5s ease-out;
+}
+
+@keyframes target-flash {
+  0% { outline: 2px solid var(--accent); outline-offset: 4px; background: rgba(157, 67, 21, 0.08); }
+  100% { outline-color: transparent; background: transparent; }
+}
+
+.status-card,
+.action-card,
+.pathway-card,
+.dataset-card,
+.faq-item {
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.status-card:hover,
+.action-card:hover,
+.pathway-card:hover,
+.dataset-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 60px rgba(40, 24, 5, 0.16);
+}
+
+/* Focus-within for keyboard parity on cards with links */
+.action-card:focus-within,
+.pathway-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 60px rgba(40, 24, 5, 0.16);
+}
+
+/* ── Print styles ── */
+
+@media print {
+  .site-nav,
+  .docs-sidebar,
+  .docs-toc,
+  .search-dialog,
+  .site-nav-mobile,
+  .version-bar,
+  .hero-actions,
+  .section-nav,
+  .footer-links {
+    display: none !important;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  .hero,
+  .panel,
+  .notice-panel,
+  .footer {
+    backdrop-filter: none;
+    box-shadow: none;
+    border-color: #ccc;
+  }
+
+  .docs-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  details {
+    display: block;
+  }
+
+  details > * {
+    display: block;
+  }
+
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  section {
+    break-inside: avoid;
+  }
+
+  h2, h3 {
+    break-after: avoid;
+  }
+}
+
 .footer {
   margin-top: 1.2rem;
   padding: 1.2rem 1.4rem;
@@ -536,6 +1629,15 @@ a {
   color: inherit;
 }
 
+@media (max-width: 1280px) {
+  .docs-toc {
+    display: none;
+  }
+  .docs-grid {
+    grid-template-columns: 260px minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 980px) {
   .hero-grid,
   .status-grid,
@@ -551,8 +1653,20 @@ a {
     flex-direction: column;
   }
 
-  .top-nav {
+  .section-nav {
     justify-content: flex-start;
+  }
+
+  .docs-grid {
+    grid-template-columns: 1fr;
+  }
+  .docs-sidebar {
+    position: static;
+    max-height: none;
+    border-bottom: 1px solid var(--line);
+    padding-right: 0;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add global SiteNav (sticky header, search dialog with Pagefind, dark mode toggle, mobile hamburger), DocsLayout with three-column grid (sidebar, content, table of contents), breadcrumbs, and Astro content collections with 6 migrated data-model docs
- Add dark mode with full CSS custom property swap, view transitions, accordion FAQ, card hover interactions, anchor highlighting, print styles, version bar above hero, and StatusBadge component
- Integrate @astrojs/mdx and @astrojs/sitemap; add dev server launch configs

## Test plan
- [ ] Run `npm run build` in the site directory — should produce 11 pages with no errors
- [ ] Run `npm run dev` and verify homepage renders with SiteNav, version bar, and hero
- [ ] Navigate to `/docs/data-model/parcel-state-schema.html` and verify three-column layout (sidebar, content, ToC)
- [ ] Toggle dark mode via the sun/moon button in the nav — verify all elements swap correctly
- [ ] Resize to mobile width (<760px) — verify hamburger menu appears and sidebar stacks above content
- [ ] Open FAQ page — verify accordion items expand/collapse
- [ ] Check print preview — verify nav/sidebar hidden, details forced open

🤖 Generated with [Claude Code](https://claude.com/claude-code)