### PR TITLE
feat(architecture): platform programs, parts, OSI posture, ADRs 0007-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ OESIS is split across four repositories:
 | **[oesis-hardware](https://github.com/lumenaut-llc/oesis-hardware)** | Sensor node specs, build guides, firmware, BOMs | CERN-OHL-S-2.0 / AGPL-3.0 |
 | **[oesis-public-site](https://github.com/lumenaut-llc/oesis-public-site)** | Public preview website | AGPL-3.0 |
 
+## Navigating this repo
+
+This repository holds architecture, contracts, release materials, and governance for OESIS. It is large (hundreds of markdown files) because the program has four independent version axes (program phase / capability stage / deployment maturity / runtime lane), multiple node families, and cross-repo coordination. Use this map to land on the right doc quickly.
+
+### Top-level directories
+
+| Directory | What lives there |
+|---|---|
+| [`architecture/`](architecture/) | Versioned architecture canon — `current/` (frozen v0.1), `system/` (cross-version), `v1.0/` (debated target), `v1.5/` (bridge stage), `decisions/` (doctrine), `future/` (redirect-only alias) |
+| [`program/`](program/) | Program framing, phasing, operating packet — `operating-packet/` is the numbered program narrative; `v0.1/`…`v0.5/` are per-slice framing |
+| [`release/`](release/) | Release packets and sign-off artifacts per slice — `v.0.1/` (canonical v0.1 release), `v0.2/`…`v1.5/` |
+| [`legal/`](legal/) | Privacy, licensing, governance rules, defensive publication, counsel questions — per-slice subdirectories |
+| [`operations/`](operations/) | Pilot docs, operator-facing checklists, per-slice rollout material |
+| [`software/`](software/) | Subsystem architecture prose (ingest-service, inference-engine, parcel-platform, shared-map). Canonical implementation tree lives in the sibling [oesis-runtime](https://github.com/lumenaut-llc/oesis-runtime) repo |
+| [`meta/`](meta/) | Manifests, ADRs, doc-discipline policy, proposals, print bundles |
+| [`artifacts/`](artifacts/) | Generated bundles (contracts-bundle, public-content-bundle, runtime-evidence-bundle) and per-slice artifact snapshots |
+
+### Reading paths by goal
+
+Pick the scenario that matches what you want, then follow the chain:
+
+- **"What is OESIS, at a glance?"** → this README (top) → [`architecture/system/vision-and-use-cases.md`](architecture/system/vision-and-use-cases.md) → [`program/operating-packet/01-core-thesis-and-framing.md`](program/operating-packet/01-core-thesis-and-framing.md)
+- **"I want to contribute runtime code."** → [oesis-runtime README](https://github.com/lumenaut-llc/oesis-runtime/blob/main/README.md) → [`architecture/current/reference-stack.md`](architecture/current/reference-stack.md) → [`architecture/current/v0.1-acceptance-criteria.md`](architecture/current/v0.1-acceptance-criteria.md) → [`architecture/current/v0.1-runtime-modules.md`](architecture/current/v0.1-runtime-modules.md)
+- **"I want to design or build hardware."** → [oesis-hardware README](https://github.com/lumenaut-llc/oesis-hardware/blob/main/README.md) → [oesis-builds GUIDE](https://github.com/lumenaut-llc/oesis-builds/blob/main/GUIDE.md) → [`architecture/system/deployment-maturity-ladder.md`](architecture/system/deployment-maturity-ladder.md) → [`architecture/system/calibration-program.md`](architecture/system/calibration-program.md) → [`architecture/system/parts/`](architecture/system/parts/) (per-node part sheet)
+- **"I want to review a promotion (v0.2, v1.0, etc.)."** → [`release/v.0.1/v0.1-scope-matrix.md`](release/v.0.1/v0.1-scope-matrix.md) (sign-off shape) → [`architecture/current/pre-1.0-version-progression.md`](architecture/current/pre-1.0-version-progression.md) (5-item promotion bar) → [`architecture/system/architectural-choices-by-stage.md`](architecture/system/architectural-choices-by-stage.md) (master summary) → [`release/v.0.1/v0.1-gap-register.md`](release/v.0.1/v0.1-gap-register.md) (G1–G24)
+- **"I want to understand a specific node family."** → [`architecture/system/parts/<node>.md`](architecture/system/parts/) (aggregator page, 6 nodes) → [`architecture/system/node-taxonomy.md`](architecture/system/node-taxonomy.md) (taxonomy) → cross-repo design: [oesis-hardware/<node>/](https://github.com/lumenaut-llc/oesis-hardware) → cross-repo execution: [oesis-builds/specs/<node>/](https://github.com/lumenaut-llc/oesis-builds/tree/main/specs)
+
+### Other navigation surfaces (don't duplicate — extend)
+
+The repo already has navigation artifacts for specific concerns:
+
+- [`architecture/README.md`](architecture/README.md) — architecture-specific reading order and lane-vocabulary map.
+- [`meta/markdown-canonical-topic-matrix.md`](meta/markdown-canonical-topic-matrix.md) — authority map: which lane is canonical for overlapping topics, which are redirects.
+- [`meta/repo-manifest.md`](meta/repo-manifest.md) — file-level manifest of the repo.
+- [`meta/doc-discipline.md`](meta/doc-discipline.md) — rules for when to extend an existing doc vs create a new one; read before adding a new `.md` file.
+
+If the navigation you need isn't captured above, extend one of these rather than creating a new navigation doc (per the discipline rule).
+
 ## Quick start
 
 ### 1. Read the specs (this repo)

--- a/architecture/current/README.md
+++ b/architecture/current/README.md
@@ -79,15 +79,27 @@ authored **alongside** them (repo root and `program/`):
 1. `technical-philosophy.md`
 2. `reference-stack.md`
 3. `minimum-functioning-v0.1.md`
-4. `milestone-roadmap.md` — delivery sequence and relationship to program phases
-5. `v0.1-runtime-modules.md` — runtime package map (sibling checkout
+4. `v0.1-boundary-and-non-goals.md` — what v0.1 IS and IS NOT (scope boundary)
+5. `milestone-roadmap.md` — delivery sequence and relationship to program phases
+6. `v0.1-runtime-modules.md` — runtime package map (sibling checkout
    `../../../oesis-runtime`; see `implementation-posture.md` canonical homes)
-6. `v0.1-acceptance-criteria.md` — CLI/HTTP acceptance for the frozen slice
-7. `measurement-and-kpis-v0.1.md` — KPI family emphasis and traceability to acceptance
-8. `architecture-object-map.md`
-9. `implementation-posture.md`
-10. `component-boundaries.md`
-11. `pre-1.0-version-progression.md`
+7. `v0.1-acceptance-criteria.md` — CLI/HTTP acceptance for the frozen slice
+8. `measurement-and-kpis-v0.1.md` — KPI family emphasis and traceability to acceptance
+9. `architecture-object-map.md`
+10. `implementation-posture.md`
+11. `component-boundaries.md`
+12. `pre-1.0-version-progression.md`
+13. `v1.0-parcel-kit-architecture.md` — current-aligned design for the v1.0 target kit (bench-air + mast-lite + optional flood-node)
+
+## Why cross-version docs live in `current/`
+
+Three files in this lane describe content that spans program phases, yet they live here rather than in `../v1.0/`:
+
+- `milestone-roadmap.md` orders milestones from v0.1 (Milestone 1) through the v1.0-family targets (Milestones 2–5). It sits in `current/` because every milestone's sequencing is **current-implementation-aligned** — it describes how the program actually plans to grow the accepted reference slice, not a speculative alternative.
+- `pre-1.0-version-progression.md` defines the cross-version promotion bar. It lives in `current/` because the promotion policy is current truth the program operates under, not a proposal.
+- `v1.0-parcel-kit-architecture.md` describes the next accepted kit at the **detail level of the current design**, not as a debated alternative. Debated target-lane framing (goals, deltas, proposals, open questions) lives in `../v1.0/`; the concrete kit design that will be built lives here alongside v0.1 specifics.
+
+Rule of thumb: if a document describes the **accepted** trajectory or current design even when that trajectory extends beyond v0.1, it belongs in `current/`. If a document proposes an **alternative** to the accepted trajectory, it belongs in `../v1.0/`.
 
 ## Primary source alignment
 

--- a/architecture/current/architecture-object-map.md
+++ b/architecture/current/architecture-object-map.md
@@ -259,6 +259,58 @@ Main sources:
 - `../../release/v0.1/implementation-status-matrix.md` (release label `v0.1`, filesystem path `v0.1/`)
 - `../../software/parcel-platform/README.md`
 
+### 12. Calibration session / reference instrument
+
+Status: `docs-only`
+
+Role:
+- per-device record of a calibration session against a characterized reference instrument
+- authoritative source for a node's current calibration state (the field already referenced in §1 and §6)
+- produced under `oesis-builds/procedures/<node>/calibration.md` per `../system/calibration-program.md` §E
+
+Current `v0.1` use:
+- placeholder `references/TBD.md` file exists under bench-air procedures; no populated reference instrument yet (tracked as v0.1 gap register G13)
+- calibration session log format defined in calibration-program §E; no sessions logged yet
+
+Main sources:
+- `../system/calibration-program.md`
+- per-node calibration procedures under [`oesis-builds/procedures/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/procedures)
+
+### 13. Admissibility fact
+
+Status: `planned`
+
+Role:
+- runtime-computed decision per normalized observation
+- carries `admissible_to_calibration_dataset: bool` plus reason codes
+- filters which readings can train hazard-formula coefficients or shape parcel-state claims
+- derived from schema facts carried on the canonical observation (tracked as v0.1 gap register G17)
+
+Current `v0.1` use:
+- not yet implemented in ingest or inference (tracked as v0.1 gap register G15)
+- facts the decision depends on are not yet in the observation schema (tracked as G17)
+
+Main sources:
+- `../system/calibration-program.md` §C
+- `../system/adapter-trust-program.md` §C
+
+### 14. Adapter source authority
+
+Status: `planned`
+
+Role:
+- declared origin for Tier 1 passive inference methods and Tier 2 cloud-API adapter data
+- carries pinned API contract version, authentication model, cross-check posture
+- analogous to reference instrument for physical sensors — the anchor against which adapter data is trusted
+
+Current `v0.1` use:
+- no adapters exist in v0.2 scope; this object becomes load-bearing at capability stage v1.5 (tracked as v0.1 gap register G18)
+- policy defined in `../system/adapter-trust-program.md`
+
+Main sources:
+- `../system/adapter-trust-program.md` §A
+- `../system/node-taxonomy.md` tiered acquisition model (Tier 1 / 2 / 3)
+
 ## Layered view
 
 The grouping below is the **object-map** shorthand for navigation. **Canonical
@@ -299,6 +351,12 @@ layer names and purposes** are in `../../program/operating-packet/05-revised-arc
 - export bundles
 - operator access events
 - retention cleanup reports
+
+### Trust and admissibility layer
+
+- calibration session / reference instrument
+- admissibility fact
+- adapter source authority (capability-stage `v1.5` bridge)
 
 ### Response and verification layer (capability-stage `v1.5` bridge)
 

--- a/architecture/current/component-boundaries.md
+++ b/architecture/current/component-boundaries.md
@@ -40,6 +40,8 @@ versioned architecture canon.
 - `technical-philosophy.md`
 - `reference-stack.md`
 - `implementation-posture.md`
+- `../system/calibration-program.md`
+- `../system/adapter-trust-program.md`
 
 These files define the current cross-subsystem architecture.
 
@@ -58,6 +60,8 @@ These materials constrain what the architecture may do and claim.
 - shared-map stays downstream of parcel-private reasoning and policy-gated
 - docs-facing wrappers should not become competing implementations of the sibling
   **`oesis-runtime`** checkout (see **Canonical implementation** above)
+- calibration program and adapter-trust program own admissibility policy; ingest enforces and emits the decision; inference and parcel-platform consume but do not override
+- build specs in `oesis-builds/specs/<node>/` and adapter specs in `oesis-builds/specs/adapters/<adapter>/` own the §F metadata declaration; program-specs owns the policy those specs declare against
 
 ## Version rule
 

--- a/architecture/current/implementation-posture.md
+++ b/architecture/current/implementation-posture.md
@@ -117,6 +117,18 @@ Keep these concepts separate:
 - Trust scoring computation (5-factor model: freshness, node_health, calibration_state, install_quality, source_diversity)
 - All v0.5 governance inherited and tested
 
+### Calibration program and admissibility (docs-only / planned)
+
+- `../system/calibration-program.md` and `../system/adapter-trust-program.md`: **docs-only** (policy published 2026-04-19)
+- Reference instrument program execution (per-measurand per-deployment-class reference files under `oesis-builds/procedures/<node>/references/`): **planned** — tracked as G13
+- Burn-in gate enforcement in bring-up acceptance: **planned** — tracked as G14
+- Build-spec §F metadata blocks on node specs: **planned** — bench-air G16, mast-lite G12
+- Admissibility rule in ingest (`admissible_to_calibration_dataset` + reasons): **planned** — tracked as G15
+- Observation schema facts required by admissibility (cross-repo change to `oesis-contracts`): **planned** — tracked as G17
+- Adapter-trust program execution: **planned** — tracked as G18; load-bearing at capability stage v1.5
+
+Trust scoring (already listed under v1.0) consumes the `calibration_state` field. Once the calibration program executes, `calibration_state` will be populated by calibration sessions per calibration-program §E rather than by manual declaration.
+
 ### Additional normalization (implemented)
 
 - Circuit-monitor packet normalization and equipment-state bridge
@@ -132,6 +144,10 @@ Keep these concepts separate:
 - Installation metadata guided input surface
 - Sharing settings product UI
 - User-facing evidence view (beyond JSON)
+- Reference instrument program (characterized references per measurand per deployment class)
+- Build-spec §F metadata blocks
+- Admissibility rule runtime wiring
+- Observation schema extensions in `oesis-contracts` (admissibility facts)
 
 ### Hardware posture
 

--- a/architecture/current/milestone-roadmap.md
+++ b/architecture/current/milestone-roadmap.md
@@ -124,13 +124,36 @@ disconnected devices.
 - add `mast-lite`
 - bind both nodes through one parcel-scoped node registry
 - extend parcel evidence summaries so source mix is understandable
+- adopt **hazard formula v1** for smoke and heat per
+  `../../software/inference-engine/hazard-formula-v1.md`: sensor-primary
+  log-odds form, device-relative gas-resistance baseline, provenance-tagged
+  coefficients, divergence channels reported separately from probability
 
 ### Build requirements
 
 - stable indoor reference node installation
 - stable sheltered outdoor reference node installation
+- **`mast-lite` hardware build spec** published under
+  `oesis-builds/specs/mast-lite/v0-1.md`, with BOM, wiring, firmware pin-out,
+  and an independently reproducible build procedure
+- **`mast-lite` calibration procedure** published under
+  `oesis-builds/procedures/mast-lite/calibration.md`, citing at least one
+  characterized reference instrument (shared or distinct from bench-air P0.1)
+- **`mast-lite` radiation-shield design** documented in the build spec,
+  specifying passive or active ventilation and thermal-loading acceptance
+  tests; outdoor SHT45 readings without the shield are not admissible into
+  the calibration dataset
 - one registry model that binds both nodes to one `parcel_id`
 - install metadata and calibration state that operators and inference can trust
+- `v1_1/` inference module running **in shadow** alongside `v1_0/`, emitting
+  v1 probabilities and divergence to a versioned sink without affecting
+  user-visible parcel state
+- per-device rolling baseline maintained for bench-air gas resistance
+  (median + MAD over a 48 h window with recent-exclusion)
+- pilot incident labels ingested into a calibration dataset matching the
+  pilot-log readiness checklist in `hazard-formula-v1.md`
+- provenance schema enforced on every numeric entry in the v1 config; entries
+  without provenance fail validation
 
 ### Acceptance criteria
 
@@ -138,14 +161,40 @@ disconnected devices.
 - both nodes are bound to one parcel through the registry path
 - ingest and inference remain singular rather than splitting by node family
 - parcel outputs clearly explain indoor versus sheltered outdoor evidence
+- `mast-lite` build spec, calibration procedure, and radiation-shield design
+  exist in `oesis-builds/` and have been independently reproduced at least
+  once (closes gap register G12)
 - `mast-lite` survives sheltered outdoor validation without frequent resets or
   disappearing devices
+- `mast-lite` outdoor temperature readings pass a documented thermal-loading
+  acceptance test against the radiation shield; pre-shield readings are
+  excluded from the calibration dataset
+- **both** `bench-air-node` and `mast-lite` meet `deployment maturity v1.0`
+  calibration posture per
+  [`../system/calibration-program.md`](../system/calibration-program.md) —
+  reference instruments populated per measurand per deployment class,
+  burn-in gate enforced, admissibility rule active on ingest, build-spec
+  metadata block complete. Bench-air's v0.1 sign-off is not reopened;
+  the v0.2 promotion bar requires bench-air to reach v1.0 posture
+  forward. (Retroactivity scope per
+  [`pre-1.0-version-progression.md`](pre-1.0-version-progression.md).)
+- v1 hazard formula achieves better Brier score **and** better expected
+  calibration error than v0 replayed on the same pilot labels, per hazard,
+  before promotion from shadow
+- divergence against public/shared context is reported on every parcel-state
+  output when remote context is available; divergence never modifies `P_h`
+  directly
+- sensor-primacy contract holds numerically: `beta_sensor` exceeds the sum of
+  absolute prior coefficients by the margin configured in v1
 
 ### Current posture
 
 - `bench-air-node`: `implemented`
 - `mast-lite` software normalization and inference: `implemented` (v0.2+; shared `oesis.bench-air.v1` lineage)
 - `mast-lite` hardware independent build reproduction: `partial` (build guide exists; not independently confirmed)
+- `mast-lite` hardware build spec, calibration procedure, radiation-shield
+  design in `oesis-builds/`: **missing** (blocker; tracked as G12 and as
+  Phase 0.3 in `software/inference-engine/hazard-formula-v1-phase1.md`)
 - stronger registry-driven lifecycle: `implemented` at API level (v0.4 acceptance); operator-facing flow not yet built
 
 ## Milestone 3: hazard-module expansion

--- a/architecture/current/pre-1.0-version-progression.md
+++ b/architecture/current/pre-1.0-version-progression.md
@@ -47,9 +47,32 @@ Before promoting a new pre-`1.0` version such as `v0.2`, require:
 2. explicit contract and runtime boundary changes
 3. explicit acceptance commands or check updates
 4. explicit implementation-status evidence showing what changed
+5. **calibration-program compliance** at the target deployment-maturity
+   tier for every node family the widened slice includes, per
+   [`../system/calibration-program.md`](../system/calibration-program.md).
+   This covers reference-instrument files, burn-in gate enforcement,
+   admissibility rule on ingest, and the build-spec metadata block
+   required in `calibration-program.md` §F.
 
 If those conditions are not met, keep the work inside the current accepted lane
 and track it through milestones and status posture.
+
+### Retroactivity
+
+Calibration-program compliance applies **forward**, not retroactively.
+Slices already promoted (currently `v0.1`) retain their original posture —
+the frozen-slice principle in
+[`../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md`](../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md)
+protects against rewriting sign-off records. However, node families
+continuing into a new slice must meet that slice's calibration-program bar.
+
+Practical example: bench-air shipped at `deployment maturity v0.1` under the
+original `v0.1` promotion. v0.1 sign-off is not reopened. But because
+bench-air is one of the two node families in the `v0.2` promotion target
+(bench-air + mast-lite), bench-air must reach `deployment maturity v1.0`
+calibration posture as part of the `v0.2` promotion bar. Same bar for
+mast-lite. No node family crosses into a new slice at a lower maturity
+than the slice requires.
 
 ## Related docs
 

--- a/architecture/current/reference-stack.md
+++ b/architecture/current/reference-stack.md
@@ -76,6 +76,10 @@ Normalization and ingest behavior should treat **timing, receipts, dedupe/replay
 and staleness** as core truth surfaces, consistent with `../../program/operating-packet/05-revised-architecture-blueprint.md`
 §2 and `implementation-posture.md`.
 
+Admissibility decisions are a first-class output of this layer. For each
+normalized observation, ingest emits `admissible_to_calibration_dataset: bool`
+plus `admissibility_reasons: [string]` per [`../system/calibration-program.md`](../system/calibration-program.md) §C (or [`../system/adapter-trust-program.md`](../system/adapter-trust-program.md) §C for adapter-derived data). The decision is runtime-computed; the facts it depends on are carried in the canonical observation schema (tracked as gap G17).
+
 Entry surfaces:
 
 - `make oesis-validate`
@@ -92,6 +96,9 @@ See also `v0.1-runtime-modules.md` and `v0.1-acceptance-criteria.md`.
 - [`parcel-context-schema.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/parcel-context-schema.md)
 - [`node-registry-schema.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/node-registry-schema.md)
 - [`explanation-payload-schema.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/explanation-payload-schema.md)
+- Observation schema extensions for admissibility facts are tracked in v0.1 gap register G17 (cross-repo change to `oesis-contracts`)
+- [`../system/calibration-program.md`](../system/calibration-program.md) — program-level calibration policy for physical sensors
+- [`../system/adapter-trust-program.md`](../system/adapter-trust-program.md) — program-level trust policy for Tier 1 / Tier 2 adapter-derived data
 
 ### Parcel inference
 

--- a/architecture/current/v0.1-acceptance-criteria.md
+++ b/architecture/current/v0.1-acceptance-criteria.md
@@ -16,6 +16,19 @@ from this file; from the **program-specs repository root**, `../oesis-runtime`).
 Opt-in parallel lanes (e.g. `v1.0`) are out of scope for this checklist unless
 explicitly noted.
 
+## Deployment posture
+
+The v0.1 acceptance criteria apply to a node operating at **deployment-maturity `v0.1`** per [`../system/deployment-maturity-ladder.md`](../system/deployment-maturity-ladder.md) — bench-grade, not field-hardened. Architectural posture at v0.1:
+
+- **Deployment class:** indoor
+- **Power tier:** USB (from a protected adapter); battery/solar and mains-with-outdoor-PSU are out of scope
+- **IP rating tier:** none / IP20 acceptable (indoor class default)
+- **Transport tier:** serial-only (the v0.1 floor per gap register G3); Wi-Fi / LoRa / cellular are deferred to later lanes
+- **Calibration rigor:** provisional per calibration-program `deployment maturity v0.1` tier in [`../system/calibration-program.md`](../system/calibration-program.md) §G; characterized reference instruments not required at this tier
+- **Admissibility:** v0.1 readings are **not** admissible to the calibration dataset used for hazard-formula coefficient fitting per calibration-program §C; they are useful for software validation and reference pipeline demos
+
+Promotion to a broader posture (indoor+sheltered kit, field-hardened, admissible readings) happens at program-phase `v0.2` / Milestone 2 per [`pre-1.0-version-progression.md`](pre-1.0-version-progression.md).
+
 ## Product criteria (from the v0.1 plan)
 
 | # | Criterion | Notes |

--- a/architecture/current/v0.1-boundary-and-non-goals.md
+++ b/architecture/current/v0.1-boundary-and-non-goals.md
@@ -41,6 +41,10 @@ v0.1 explicitly excludes the following capabilities. Each is addressed by a late
 | Ingest authorization | Any client can post | Tier B (deferred) |
 | Network transport | Serial only | Tier B (deferred) |
 | Persistent history | Snapshot only | Deferred |
+| Field-hardened power / enclosure | USB-only bench power; no IP rating | v0.2+ (per `../system/deployment-maturity-ladder.md` Deployment-class standards) |
+| Battery / solar / mains-outdoor power | Not needed at indoor class | v0.2+ for sheltered-class nodes; v0.3+ for outdoor-class nodes |
+| Characterized reference instruments | Not required at `deployment maturity v0.1` | v0.2 promotion bar per `../system/calibration-program.md` §G |
+| Calibration-dataset admissibility | v0.1 readings are not admissible to coefficient fitting per calibration-program §C | v0.2+ (once §F / §G compliance is met) |
 
 ## Why this boundary matters
 

--- a/architecture/current/v1.0-parcel-kit-architecture.md
+++ b/architecture/current/v1.0-parcel-kit-architecture.md
@@ -36,6 +36,8 @@ The v1.0 inference pipeline includes a 5-factor trust scoring model that quantif
 
 Trust scoring feeds into the parcel view as `overall_band` (high, medium, low, degraded) and `overall_score` (0.0-1.0). A two-node kit with both nodes healthy typically scores in the "high" band. A single-node kit with stale data may degrade to "medium" or "low".
 
+The `calibration_state` factor is populated by the calibration program (see [`../system/calibration-program.md`](../system/calibration-program.md)). A node without a populated §F build-spec metadata block, or whose most recent calibration session is beyond the re-verification cadence, produces readings that fail the admissibility check in calibration-program §C. Such readings remain in audit logs but do not contribute to trust scoring or coefficient fitting.
+
 ## Power architecture
 
 All v1.0 nodes use USB 5V power:
@@ -52,6 +54,8 @@ See [`parcel-kit/power-source-guide.md`](https://github.com/lumenaut-llc/oesis-h
 - **Software:** all 6 acceptance commands pass (v0.1 through v1.0); trust scoring, governance, multi-node composition implemented
 - **Hardware:** bench-air is repeatable; mast-lite has a build guide but no independent field reproduction; flood-node has a build guide with provisional calibration only
 - **Field readiness:** requires the shared field-hardening checklist to be satisfied (see [`parcel-kit/field-hardening-checklist.md`](https://github.com/lumenaut-llc/oesis-hardware/blob/main/parcel-kit/field-hardening-checklist.md))
+
+Honest "deployment maturity v1.0" claims also require calibration-program compliance at the v1.0 tier per [`../system/calibration-program.md`](../system/calibration-program.md) §G: reference instruments populated, burn-in gates enforced, build-spec §F metadata blocks complete for each node in the kit. Until the compliance bar is met, claim "deployment maturity v0.1" regardless of software lane status. The promotion-bar retroactivity rule in [`pre-1.0-version-progression.md`](pre-1.0-version-progression.md) applies — bench-air's v0.1 sign-off is not reopened, but bench-air must reach v1.0 calibration posture as part of the v0.2 promotion bar.
 
 ## What v1.0 Tier A covers
 
@@ -74,8 +78,10 @@ Tier A (internal reference) proves the software stack with fixture data:
 - Named BOM vendor decisions
 - Mast-lite independent field reproduction
 - Flood-node field validation beyond provisional calibration
+- Calibration program compliance (reference instruments populated, §F metadata blocks, admissibility tooling)
+- Adapter-trust program (n/a for v0.2 scope; applies when `equipment-state-adapter` lands in v1.5)
 
-These are tracked in `../../release/v1.0/v1.0-gap-register.md`.
+These are tracked in `../../release/v1.0/v1.0-gap-register.md` and `../../release/v.0.1/v0.1-gap-register.md`.
 
 ## Inference capabilities by lane
 

--- a/architecture/system/README.md
+++ b/architecture/system/README.md
@@ -59,6 +59,59 @@ Program-level system narrative and top-level operating model.
 - `household-recommendation-catalog.md` inventories candidate household action guidance.
 - Root-level canonical overview files still contain additional program framing and should be reconciled here over time.
 
+## Files in this lane, grouped by concern
+
+The flat `system/` directory holds ~30 canonical documents plus the `parts/` subdirectory. Grouped for discoverability — each entry links to the file and names its job in one line. Authority between `system/` and other lanes is resolved in [`../../meta/markdown-canonical-topic-matrix.md`](../../meta/markdown-canonical-topic-matrix.md); this section is navigation, not reauthorization.
+
+### Version axes and promotion
+- [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md) — four-axis model (accepted slice / capability stage / deployment maturity / impl status).
+- [`phase-roadmap.md`](phase-roadmap.md) — Stages A–F with per-stage deployment posture.
+- [`architecture-gaps-by-stage.md`](architecture-gaps-by-stage.md) — gaps placed at the stage they must become explicit.
+- [`architectural-choices-by-stage.md`](architectural-choices-by-stage.md) — master summary of class / power / IP / transport / calibration per program-phase.
+
+### Integrated parcel system
+- [`integrated-parcel-system-spec.md`](integrated-parcel-system-spec.md) — unified parcel-kit architecture; hardware role map + deployment posture per node.
+- [`node-taxonomy.md`](node-taxonomy.md) — canonical node-family classification with posture tags; tiered acquisition model.
+- [`parts/`](parts/) — per-node aggregator pages (bench-air-node, mast-lite, flood-node, weather-pm-mast, thermal-pod, circuit-monitor).
+- [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md) — placement → deployment class map; sensor variant selection principles.
+- [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) — deployment-class standards (power / IP / transport per class) + field-hardening bundle.
+
+### Platform programs (physical + adapter)
+- [`calibration-program.md`](calibration-program.md) — reference instruments, burn-in, admissibility, drift, §F build-spec metadata block, §G promotion-bar compliance. Physical sensors.
+- [`adapter-trust-program.md`](adapter-trust-program.md) — parallel program for Tier 1 / Tier 2 adapter-derived data.
+
+### Philosophy + technical posture
+- [`technical-philosophy-and-architecture.md`](technical-philosophy-and-architecture.md) — top-level principles and architectural rules.
+- [`cross-repo-architecture.md`](cross-repo-architecture.md) — how the four repos work together; calibration/admissibility cross-repo flow.
+
+### Product framing
+- [`vision-and-use-cases.md`](vision-and-use-cases.md) — long-term product vision, use-case surface.
+- [`product-requirements-phase-1.md`](product-requirements-phase-1.md) — first single-parcel release slice requirements.
+- [`feature-matrix-by-use-case.md`](feature-matrix-by-use-case.md) — use cases × sensors × outputs × constraints.
+
+### Operating models
+- [`block-level-operating-model.md`](block-level-operating-model.md) — shared block intelligence.
+- [`multi-unit-building-operating-model.md`](multi-unit-building-operating-model.md) — apartments, condos, shared buildings.
+- [`community-governance-and-operator-model.md`](community-governance-and-operator-model.md) — participation + operator boundaries.
+- [`resilience-hub-operating-model.md`](resilience-hub-operating-model.md) — community hubs.
+- [`neighborhood-pilot-design-package.md`](neighborhood-pilot-design-package.md) — early network-effect pilot structure.
+- [`route-readiness-model-overview.md`](route-readiness-model-overview.md) — route/access interpretation.
+
+### Shared-layer and neighborhood surfaces
+- [`shared-map-product-posture.md`](shared-map-product-posture.md) — what shared map is and isn't.
+- [`neighborhood-signal-transformation-overview.md`](neighborhood-signal-transformation-overview.md) — privacy-scoped path from home signals to block intelligence.
+- [`network-effect-measurement-methodology.md`](network-effect-measurement-methodology.md) — testing whether participation improves product.
+- [`household-recommendation-catalog.md`](household-recommendation-catalog.md) — candidate household action guidance.
+- [`recommendation-engine-and-safety-language.md`](recommendation-engine-and-safety-language.md) — guidance posture and language boundaries.
+
+### Context, participants, and pilots
+- [`home-and-parcel-context-capture-standard.md`](home-and-parcel-context-capture-standard.md) — minimum context for honest interpretation.
+- [`data-rights-and-participant-controls-ux-outline.md`](data-rights-and-participant-controls-ux-outline.md) — participant-facing control model.
+- [`pilot-success-metrics-and-evaluation.md`](pilot-success-metrics-and-evaluation.md) — how pilots are judged.
+
+### Canonical links
+- [`canonical-links.md`](canonical-links.md) — link authority roll-up.
+
 ## Related workstreams
 
 - data model

--- a/architecture/system/adapter-trust-program.md
+++ b/architecture/system/adapter-trust-program.md
@@ -1,0 +1,204 @@
+# Adapter Trust Program
+
+## Lane
+
+`system/` lane. Sibling doc to [`calibration-program.md`](calibration-program.md).
+
+This doc defines the trust posture for **adapter-derived** evidence — data obtained through cloud APIs, third-party integrations, or passive inference rather than through a physical sensor owned by the project. It is structured in parallel to `calibration-program.md` so both produce the same final decision (admissibility of a reading to coefficient fitting and to inference) through different evidence paths.
+
+## Purpose
+
+`calibration-program.md` assumes a physical sensor that can be pointed at a characterized reference instrument, burned in, and checked for drift. That model does not apply to:
+
+- cloud-API adapters for third-party devices (Ecobee, Nest, Sensibo, Honeywell, SwitchBot, and similar)
+- utility or weather feeds consumed as evidence rather than as context
+- passive inference (Tier 1 in the `node-taxonomy.md` tiered acquisition model, for example thermal-slope HVAC inference)
+
+Adapter-derived evidence needs its own trust posture because its failure modes are not physical drift or conditioning — they are API contract changes, schema drift, authentication lapses, source-authority revocation, and upstream transformations invisible to the consumer.
+
+This program defines what trust looks like for that class of evidence, at policy level. Per-adapter execution lives in the adapter's build spec and runbook, analogous to how per-device calibration lives under `oesis-builds/procedures/<node>/`.
+
+## Relation to version axes
+
+Per [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md), this doc touches only the deployment-maturity axis (adapters carry their own maturity) and implementation-status axis. It does **not** introduce a capability-stage label and does not promote accepted runnable slices.
+
+## Relation to capability stage
+
+Adapter-derived evidence is a first-class surface in **capability stage `v1.5`** per [`architecture-gaps-by-stage.md`](architecture-gaps-by-stage.md): equipment-state-adapter, house-state bridge surfaces, and action/outcome logs all rely on adapter-derived data. The nodes and surfaces named there (`equipment-state-adapter`, `circuit-monitor` for Tier 3, `indoor-response-node`) each carry data of different tiers per `node-taxonomy.md`.
+
+Program-phase `v0.2` (bench-air + mast-lite) is Tier 3 only; this program has no gating role in v0.2 promotion. It becomes load-bearing at the `v1.5` bridge and beyond.
+
+## Governing principles
+
+1. **Adapter trust is not sensor calibration.** Different failure modes, different evidence. Shared output (admissibility decision) but independent mechanisms.
+2. **Source authority is the anchor.** A physical sensor's anchor is its reference instrument. An adapter's anchor is the **source authority** — the API, account, or derivation rule that produces the data. Changing the source authority re-baselines trust from scratch, the same way a replaced physical sensor re-baselines calibration.
+3. **API contract is first-class evidence.** Adapters ship against a pinned version of an external API contract. A silent upstream change without a contract version bump is a trust failure, even if values still arrive.
+4. **Cross-check against Tier 3 where possible.** When direct measurement is available for the same parcel, adapter-derived values are cross-checked against it at onboarding and periodically. Divergence triggers reduced trust, not silent acceptance.
+5. **Passive inference is the weakest tier.** Tier 1 data (passive inference from existing sensors) is admissible only when the inference method itself is characterized and the derived field carries its method-version reference.
+
+## Program components
+
+### A. Source authority registry
+
+Every adapter-derived measurand must be traceable to a declared **source authority** — the external system or derivation rule producing the data.
+
+For each source authority, the program requires a file under `oesis-builds/procedures/adapters/<adapter>/source.md` with:
+
+- source name (e.g., "Ecobee v1 Developer API")
+- authentication model (OAuth2 app, API key, PAT, etc.) and credential scope
+- pinned API contract version and effective date
+- data fields consumed (mapped to internal measurand names)
+- known refresh cadence and rate limits
+- documented failure modes (auth revocation, rate limit, API deprecation, schema drift)
+- initial cross-check against a Tier 3 reference where applicable (e.g., Ecobee indoor temperature vs indoor-response-node temperature)
+- point of contact or SLA if one exists
+- last verification date
+
+Passive inference methods (Tier 1) are treated as source authorities too: the **method itself** is the source, with a version string and a characterization record.
+
+### B. Onboarding gate
+
+Before any adapter's data is admissible, it must clear:
+
+- schema validation: the adapter produces the documented fields in the documented types
+- authentication validation: credential scope matches declared scope (no over-broad permissions)
+- cross-check against Tier 3 where a direct measurement exists for the same parcel and measurand: residual error within the bound declared in the adapter's build spec
+- documented initial verification record under `procedures/adapters/<adapter>/verification/<parcel_id>-<date>.md`
+
+For passive inference, the onboarding gate is a **method characterization**: documented derivation, expected accuracy bounds, known failure modes, and the test set against which bounds were measured.
+
+### C. Admissibility
+
+An adapter-derived reading is admissible to the calibration dataset and to inference only if all of the following hold:
+
+1. **Source authority registered.** A current source file exists under section A.
+2. **API contract version matches pinned version.** Runtime compares the adapter's reported contract version to the pinned version; mismatches produce `contract_version_drift` inadmissibility.
+3. **Onboarding gate passed for this parcel.** Cross-check and initial verification on record for this specific parcel.
+4. **Credentials current.** Adapter authentication has not expired or been revoked since last verification.
+5. **Cadence honored.** Readings arrive within the documented refresh cadence; stale readings beyond a configured freshness window are inadmissible.
+6. **Tier-appropriate confidence.** Tier 2 (cloud adapter) readings may be primary when Tier 3 is unavailable. Tier 1 (passive inference) readings are admissible only to the inference fields the method is characterized for; they are not admissible as direct-measurement substitutes.
+7. **Source-derived uncertainty within bounds.** If the adapter provides its own uncertainty or confidence field, the value falls within the bound declared in the adapter's build spec.
+8. **No open adapter incident.** The source authority has no open incident or deprecation notice that would invalidate readings in the observation's window.
+
+Admissibility decision is computed in runtime; facts required to compute it are carried on the normalized observation. The canonical fact set parallels the schema additions for physical sensors in [`calibration-program.md`](calibration-program.md) §C:
+
+- `adapter_source_ref: string` — pointer to the source file under section A
+- `adapter_contract_version: string` — version string the reading was produced against
+- `adapter_onboarding_ref: string` — pointer to the parcel's initial verification record
+- `adapter_credential_last_verified_at: timestamp`
+- `adapter_tier: enum` — one of `tier_1_passive`, `tier_2_adapter`, `tier_3_direct` per `node-taxonomy.md`
+
+Runtime produces the same-shape outputs as calibration-program §C:
+
+- `admissible_to_calibration_dataset: bool`
+- `admissibility_reasons: [string]` with adapter-specific reason codes (`contract_version_drift`, `credentials_expired`, `onboarding_missing`, `cadence_stale`, `source_incident_open`, `tier_insufficient`)
+
+**Inadmissible ≠ discarded.** Inadmissible adapter readings remain in raw logs for audit and for future re-processing if the source authority's posture is restored.
+
+### D. Drift policy
+
+Adapter drift is different from sensor drift. Three failure modes, with response tiers:
+
+- **Silent schema drift.** API returns same field names with changed semantics. Caught by periodic cross-check against Tier 3 where available, or by manual audit. Response: suspend admissibility for affected measurand until source file is updated and onboarding gate re-passed.
+- **Contract version bump.** API provider announces new version. Response: verify the pinned version in the source file; re-run onboarding gate against the new version; update pinned version only after cross-check passes.
+- **Source authority revocation or deprecation.** Credential revoked, account suspended, or API sunset. Response: immediate inadmissibility for all readings from that source; remediation is source-dependent (new auth, migration to successor API, or adapter retirement).
+
+Specific thresholds for cross-check tolerance and revocation cadences live in each adapter's build spec, not in this doc.
+
+### E. Adapter session log format
+
+Each adapter-verification session produces a record with at minimum:
+
+- session timestamp (UTC)
+- adapter identity (source name, contract version, credential scope)
+- parcel this verification applies to
+- measurand(s) verified
+- raw adapter reading(s) and raw Tier 3 reference reading(s) where available
+- residual error against reference if applicable
+- session outcome: `pass`, `cross-check drift`, `schema drift`, `credential failure`, `source incident`
+- operator identity
+- next re-verification due date
+
+Verification logs live alongside the parcel's install metadata and the adapter's build spec. They are authoritative when admissibility checks reference "this adapter's current verification state on this parcel."
+
+### F. Build-spec metadata block
+
+Every adapter configuration in `oesis-builds/specs/adapters/<adapter>/v0-X.md` carries a front-matter metadata block, parallel in shape to calibration-program §F:
+
+```yaml
+---
+adapter_family: <string, e.g. "ecobee-adapter">
+build_version: <string, e.g. "v0-1">
+tier: tier_1_passive | tier_2_adapter | tier_3_direct
+source_authority_ref: <path to source file under oesis-builds/procedures/adapters/<adapter>/source.md>
+pinned_contract_version: <string>
+measurands:
+  - name: <e.g. "hvac_mode">
+    source_field: <e.g. "runtime.equipmentStatus">
+    expected_type: <e.g. "enum">
+    uncertainty_bound: <adapter-declared confidence>
+    tier_3_cross_check_ref: <path to Tier 3 cross-check procedure if applicable, else null>
+  - name: <next measurand>
+    ...
+onboarding_requirements:
+  cross_check_against_tier_3: true | false
+  initial_verification_window_hours: <number>
+credential_model:
+  type: oauth2 | api_key | pat
+  scope: <string>
+  refresh_cadence_hours: <number or null>
+deployment_maturity_target: v0.1 | v1.0 | v1.5 | v2.0
+adapter_trust_program_revision: <commit hash or date>
+---
+```
+
+The block is consumed by the same (future, planned) admissibility tooling that reads the calibration-program §F block for physical sensors. Both feed the same decision; the tooling branches on which program's rules apply per the `tier` field.
+
+### G. Promotion-bar compliance
+
+Adapter-derived evidence participates in slice promotion (per [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md) item 5) under this program, not under calibration-program. Per-tier compliance:
+
+- **`v0.1` (bench prototype):** build-spec metadata block (§F) exists; cross-check and onboarding may be informal.
+- **`v1.0` (first fielded kit):** all components §A–§F complete; onboarding gate enforced per parcel; Tier 3 cross-check on record where applicable.
+- **`v1.5` (trust hardening):** §A–§F complete; verification logs versioned; schema-drift detection active; source-incident watch on record.
+- **`v2.0` (decision-policy):** §A–§F complete; cross-adapter consistency audit on record; retirement and replacement paths documented.
+
+Slice promotions that include adapter-derived evidence (earliest: capability stage `v1.5` bridge surfaces) inherit these tiers through the promotion bar.
+
+## Maturity ladder mapping
+
+Same tier labels as `calibration-program.md`, applied to adapters rather than sensors:
+
+| Deployment maturity | Source registry | Onboarding gate | Admissibility | Drift policy | Log format |
+|---|---|---|---|---|---|
+| `v0.1` | Best-available; may be uncharacterized | Informal | Not admissible to coefficient fits | Not tracked | Informal lab notes |
+| `v1.0` | Characterized per measurand | Enforced per parcel | Admissible if all §C items hold | Cross-check cadence tracked | Structured log per §E |
+| `v1.5` | v1.0 plus versioned verification records | Enforced | Admissible; readings carry contract-version reference | Schema-drift detection; versioned onboarding | Full §E + version field |
+| `v2.0` | v1.5 plus cross-adapter consistency audits | Enforced | Admissible; plus cross-adapter bias checks | Retirement and replacement paths enforced | Full §E + version + audit link |
+
+## Implementation status
+
+| Component | Status | Note |
+|---|---|---|
+| Source authority registry | `planned` | No adapter exists in v0.2 scope |
+| Onboarding gate | `planned` | Requires at least one adapter build to exercise |
+| Admissibility rule | `planned` | Shares runtime plumbing with calibration-program §C (G15) |
+| Drift policy | `planned` | Schema-drift detection is novel surface |
+| Adapter session log format | `docs-only` | Format defined; no logs yet |
+| Build-spec metadata block | `docs-only` | §F defined here; no adapter spec files exist |
+
+## Gap register references
+
+- **G15** — admissibility tooling runtime wiring is shared between calibration-program and adapter-trust-program; the tooling branches by tier.
+- **G18** — adapter-trust-program exists as policy; concrete adapter builds, registries, and verification records are future work gated by capability stage `v1.5`.
+- Capability-stage work for `v1.5` bridge surfaces (indoor-response-node, equipment-state-adapter, circuit-monitor) in `phase-roadmap.md` and `architecture-gaps-by-stage.md` depends on this program being in place.
+
+## Related docs
+
+- [`calibration-program.md`](calibration-program.md) — sibling program for physical-sensor trust; same output shape
+- [`node-taxonomy.md`](node-taxonomy.md) — Tier 1/2/3 acquisition model; bridge surfaces
+- [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) — maturity tiers this program scales with
+- [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md) — canonical axes
+- [`architecture-gaps-by-stage.md`](architecture-gaps-by-stage.md) — capability-stage placement
+- [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md) — slice promotion bar
+- Cross-repo: per-adapter specs at [`oesis-builds/specs/adapters/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/specs) and procedures at [`oesis-builds/procedures/adapters/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/procedures) when these come into existence

--- a/architecture/system/architectural-choices-by-stage.md
+++ b/architecture/system/architectural-choices-by-stage.md
@@ -1,0 +1,154 @@
+# Architectural Choices By Stage
+
+## Lane
+
+This document is the `system/` lane summary of architectural choices (power strategy, transport, enclosure IP rating, radiation shield, sensor variants, calibration rigor, admissibility policy) as they evolve across program phases and capability stages.
+
+## Purpose
+
+Provide a single-page answer to "what architectural choices apply at each program-phase, in total and between stages." Sibling doc to [`architecture-gaps-by-stage.md`](architecture-gaps-by-stage.md), which covers the same axis for gaps rather than choices.
+
+This doc is a **summary surface**, not a source of truth. When this doc and a cited program doc disagree, the cited program doc wins. Canonical sources:
+
+- [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) — power / IP / transport tier per deployment class; deployment-maturity rungs
+- [`calibration-program.md`](calibration-program.md) — §F build-spec metadata block; §G promotion-bar compliance per tier
+- [`adapter-trust-program.md`](adapter-trust-program.md) — parallel program for Tier 1 / Tier 2 adapter-derived data
+- [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md) — placement → deployment class map; sensor variant selection principles
+- [`node-taxonomy.md`](node-taxonomy.md) — per-node posture tags and tiered acquisition model
+- [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md) — slice promotion bar
+
+## How to read this doc
+
+1. Start with the axis legend to check which version axis you're reasoning about.
+2. Go to the master table to see the choice set that applies at a given program-phase.
+3. Go to the per-phase narrative for what changes and why.
+4. Use the between-stage deltas to see what each promotion actually adds.
+
+If you're designing a new node family, read [`calibration-program.md`](calibration-program.md) §F for the build-spec metadata schema, then declare a posture that matches this doc's cell values for the target phase.
+
+## Axis legend
+
+Per [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md), this repo uses four axes that must not collapse:
+
+- **Program phase** (accepted runnable slice): `v0.1`, `v0.2`, `v0.3`, `v0.4`, `v0.5`, `v1.0` — defines what end-to-end story is promoted.
+- **Capability stage**: `current v1`, `v1.5`, `v2`, `v2.5`, `v3`, `v4` — defines the class of product behavior in scope.
+- **Deployment maturity**: `v0.1`, `v1.0`, `v1.5`, `v2.0` per family — defines how field-hardened the hardware is.
+- **Runtime lane**: `v0.1`–`v1.5` in `oesis-runtime/oesis/assets/` — defines which capability set the runtime activates.
+
+This doc's master-table rows are **program phase**. Cells name the deployment class set, power tier, IP tier, transport tier, deployment-maturity tier, calibration rigor, adapter tier, and admissibility policy that applies at that phase.
+
+## Master table — choices by program-phase
+
+| Phase | Deployment class set | Power tier | IP tier | Transport floor | Deployment-maturity target | Calibration rigor (physical) | Adapter-trust tier (where present) | Admissibility to coefficient fitting |
+|---|---|---|---|---|---|---|---|---|
+| **`v0.1`** | indoor | USB | IP20 | serial | `v0.1` (bench) | provisional; no characterized reference required | n/a (no adapters) | **not admissible** (§C tier 2 bar not met) |
+| **`v0.2`** | indoor + sheltered | USB (indoor); 12V-DC or USB-from-indoor (sheltered) | IP20 / IP44 | serial; Wi-Fi permitted sheltered | `v1.0` (first fielded kit); retroactive for bench-air per `../current/pre-1.0-version-progression.md` | characterized references per measurand per class; burn-in gate enforced; §F metadata block complete | n/a (v0.2 is physical-sensor only) | **admissible** if §C 8-point check passes |
+| **`v0.3`** | v0.2 + outdoor (flood-node) | + battery+solar or hardened mains (outdoor) | + IP65 | + serial→LoRa | `v1.0` | v0.2 rigor + flood-node zero-reference + geometry discipline | n/a | admissible per §C |
+| **`v0.4`** | same as v0.3 | same | same | same | `v1.0` | multi-node evidence composition; per-device calibration versioning begins | n/a | admissible per §C |
+| **`v0.5`** | same as v0.3 | same | same | same | `v1.0` | v0.4 rigor + governance-gated shared-layer eligibility per G22 | n/a | admissible per §C; shared-layer gate per G22 |
+| **`v1.0`** (pre-1.0 ladder) | indoor + sheltered + outdoor (where justified) | per deployment class | per deployment class | per deployment class | `v1.0` fleet-wide | all five §A–§E components complete per family; §F block passing validation; §G tier met | Tier 3 only (circuit-monitor possible) | admissible per §C |
+| **`v1.5`** (capability-stage bridge) | + indoor bridge surfaces (indoor-response-node, power-outage-node, circuit-monitor) | + battery-backed (power-outage-node); low-power from measured circuit (circuit-monitor) | + electrical-enclosure IP20 (circuit-monitor) | + Wi-Fi / LoRa for bridge surfaces | `v1.5` (trust hardening) — versioned offsets, drift-aware | v1.0 rigor + versioned calibration state + maintenance-informed trust penalties | **Tier 1, 2, 3 all in scope** — adapters governed by `adapter-trust-program.md` | admissible per §C (physical) or adapter-trust §C (adapters); branch by `adapter_tier` |
+| **`v2`** (capability-stage guidance) | same physical as `v1.5` | same | same | same | `v1.5` | same | same; adapters at adapter-trust `v1.5` tier | admissible; guidance outputs advisory-only |
+| **`v2.5`** (capability-stage controls) | same physical as `v1.5` | same | same | same | `v2.0` (decision-policy support) | v1.5 rigor + cross-node consistency audits | all tiers + bounded-control adapters (Matter / HA / BACnet) at adapter-trust `v2.0` | admissible; bounded-control readouts enforced |
+| **`v3`** (adaptation engine) | same physical as `v1.5` | same | same | same | `v2.0` fleet-wide | retirement thresholds enforced in runtime | same | admissible; retired devices excluded |
+| **`v4`** (parcel + route + block) | + shared-layer aggregation (derived from per-parcel admissible data) | n/a (derived) | n/a | n/a | inherits per-contributor | inherits per-contributor | inherits | shared-layer contribution gated on per-contributor admissibility per G22 |
+
+**Legend:** "n/a" means the axis does not apply at that phase (e.g., adapter-trust tier is n/a in `v0.1`–`v1.0` because no adapters are in scope).
+
+## Per-phase narrative
+
+### `v0.1` — narrow executable reference slice
+
+**What hardware choice unlocks this phase.** The choice to commit to **one indoor bench-air-node, USB-powered, with serial-only transport** is what makes v0.1 executable without field infrastructure. USB is the lightest possible power assumption; serial is the lightest possible transport assumption. Together they mean a parcel can run on a laptop next to a dev board — no authorization, no Wi-Fi, no outdoor mounting, no IP rating.
+
+**What is deliberately out.** Outdoor sensing, sheltered sensing, PM2.5, radiation shields, adapters, battery/solar power, Wi-Fi transport, field-hardening. All of these are deferred not because they are unimportant, but because including them would force v0.1 to solve field problems before the reference path has proven it can produce one honest parcel view.
+
+**Calibration posture.** Provisional. v0.1 readings are useful for software validation but are **not admissible** to the calibration dataset that feeds hazard-formula coefficient fitting. Production coefficient fits require at least `v0.2` / deployment-maturity `v1.0` data per calibration-program §G.
+
+### `v0.2` — first widened kit (bench-air + mast-lite)
+
+**What hardware choices unlock this phase.** Adding **mast-lite at deployment-class sheltered** is the step from bench to field. Mast-lite requires three choices that v0.1 could avoid: (a) a power path that survives a sheltered outdoor mount (12V-DC or USB-from-indoor through a cable gland), (b) an enclosure rated to IP44 so occasional rain-splash and condensation don't break the unit, (c) a protective fixture (radiation shield) whose thermal-loading acceptance test has been passed — without which outdoor temperature readings are corrupted by solar loading and inadmissible.
+
+**What changes about calibration.** v0.2 is where the calibration program §G `v1.0` tier begins to bind. Characterized reference instruments must be populated per measurand per deployment class; burn-in gate enforced for BME680-bearing nodes; §F metadata block complete for every node family in the kit. Bench-air-node's v0.1 sign-off is not reopened (retroactivity rule in `pre-1.0-version-progression.md`), but bench-air must reach v1.0 calibration posture as part of v0.2 promotion.
+
+**Gap-register tie-ins.** G12 (mast-lite spec), G13 (reference instruments), G14 (burn-in gate), G16 (bench-air §F block) all bite here.
+
+### `v0.3` — first flood-capable slice
+
+**What hardware choices unlock this phase.** Adding **flood-node at deployment-class outdoor** extends the class set. Flood-node needs battery+solar or hardened mains (outdoor class default), IP65 (flood-node installations see standing water), and serial→LoRa (low-point mounts often beyond reliable Wi-Fi). The single most important protective-fixture choice at v0.3 is a rigid mount at a documented low-point with a zero-reference staff gauge — without documented geometry, depth numbers are decoration.
+
+**What is deliberately out.** PM2.5 (deferred to v1.0 with weather-pm-mast), thermal sensing (research-gated).
+
+### `v0.4` — multi-node registry and evidence composition
+
+**What hardware choices unlock this phase.** No new class; multi-node evidence composition across the v0.3 set. The choice at v0.4 is to require per-device calibration versioning so drift can be tracked without contaminating historical inference outputs.
+
+### `v0.5` — governance enforcement
+
+**What hardware choices unlock this phase.** No new hardware. The architectural choice is to gate shared-layer contribution on per-contributor calibration-program admissibility (G22). A well-placed but uncalibrated node cannot contribute to shared-map aggregation.
+
+### `v1.0` (pre-1.0 ladder) — first materially broader system
+
+**What choices unlock this phase.** The whole v0.1–v0.5 architecture reaching **deployment-maturity `v1.0`** fleet-wide. Every node family has a §F metadata block passing validation; every measurand has a characterized reference instrument; every node's reference-calibration is current; §G promotion-bar compliance is formally attested.
+
+### `v1.5` — measurement-to-intervention bridge
+
+**What hardware choices unlock this phase.** The key choice is introducing **adapter-derived data** as first-class evidence alongside physical sensors. Three tiers of adapter:
+
+- **Tier 1 passive inference** (zero hardware; e.g., thermal-slope HVAC detection) — the inference method itself is the source authority.
+- **Tier 2 cloud API** (Ecobee, Nest, Sensibo, Honeywell) — no physical power; governed by API contract version and schema-drift detection.
+- **Tier 3 direct measurement** (circuit-monitor) — physical power (low-power from measured circuit), electrical-enclosure IP20, Wi-Fi transport.
+
+`indoor-response-node` and `power-outage-node` are new physical-sensor classes at v1.5 as well; `power-outage-node`'s power is **battery-backed** (intrinsic: a continuity monitor that loses power is useless). Calibration rigor steps up to `v1.5` (versioned offsets, drift-aware).
+
+### `v2` — bounded adaptation guidance
+
+**What hardware choices unlock this phase.** None new; software layer on v1.5 hardware. Adapter-trust tier for every consumed adapter must be at `v1.5` (verification logs versioned, schema-drift detection active).
+
+### `v2.5` — bounded controls and compatibility mapping
+
+**What hardware choices unlock this phase.** Introduces control-side adapter surfaces (Matter, Home Assistant, BACnet, smart plugs). Physical-sensor requirements unchanged from v1.5; adapter-trust tier for control adapters must be at `v2.0` (cross-adapter consistency audits, retirement/replacement paths documented). Bounded controls are reversible, low-risk, and verifiable by construction — every action enters an outcome log so its effect can be measured.
+
+### `v3` — parcel adaptation engine
+
+**What hardware choices unlock this phase.** None new. The architectural choice is to require `deployment maturity v2.0` **fleet-wide**: retirement thresholds enforced in runtime, learned priors do not encode defunct devices as baseline.
+
+### `v4` — parcel + route + block resilience
+
+**What hardware choices unlock this phase.** None new per parcel. The scaling choice is that shared-layer contribution is gated on per-contributor admissibility per gap G22 — parcel-private data that fails admissibility does not flow to block-level aggregation.
+
+## Between-stage deltas
+
+What changes at each promotion:
+
+- **`v0.1` → `v0.2`:** adds sheltered deployment class; adds 12V-DC power tier; adds IP44; adds radiation-shield protective fixture; enters calibration-program §G `v1.0` tier; readings become admissible to coefficient fitting.
+- **`v0.2` → `v0.3`:** adds outdoor deployment class; adds battery+solar power tier; adds IP65; adds LoRa permitted transport; adds flood-node rigid mount + zero-reference fixture.
+- **`v0.3` → `v0.4`:** no class / power / IP / transport change; adds per-device calibration versioning (deployment-maturity `v1.5` anticipation).
+- **`v0.4` → `v0.5`:** no hardware change; adds shared-layer eligibility gating on per-contributor admissibility.
+- **`v0.5` → pre-1.0 `v1.0`:** all v0.2–v0.5 rigor now **fleet-wide** with §F metadata blocks passing validation; §G tier `v1.0` formally attested for every node family.
+- **`v1.0` → capability-stage `v1.5`:** adds adapter-derived data (Tier 1, 2, 3); adds `indoor-response-node` + `power-outage-node` + `circuit-monitor` hardware; adds battery-backed power tier (for continuity-monitor use case); adds electrical-enclosure class (for circuit-monitor); calibration rigor steps to `v1.5` (versioned offsets).
+- **`v1.5` → `v2`:** no hardware change; adapter-trust tier floor becomes `v1.5` for every consumed adapter.
+- **`v2` → `v2.5`:** adds bounded-control adapters (Matter / HA / BACnet); adapter-trust tier floor becomes `v2.0` for control adapters; calibration-program §G `v2.0` (cross-node bias audits) required.
+- **`v2.5` → `v3`:** no hardware change; calibration-program §G `v2.0` now **fleet-wide**; retirement thresholds enforced in runtime.
+- **`v3` → `v4`:** no per-parcel hardware change; introduces shared-layer aggregation surfaces; per-contributor admissibility gates shared-layer eligibility per G22.
+
+## Non-goals
+
+- This doc does not replace per-stage docs. It is a summary surface. Per-stage docs (`v0.1-acceptance-criteria.md`, `phase-roadmap.md`, `09-phasing-v0.1-v1.0-v1.5.md`, `v1.0-scope.md`, etc.) carry the authoritative per-stage detail in context.
+- This doc does not introduce new vocabulary. Every term it uses is canonical per the sources listed in "Purpose".
+- This doc does not promote any accepted slice. Promotion follows `pre-1.0-version-progression.md` item 5 (calibration-program compliance at target deployment-maturity tier).
+- **If this doc and the ladder / calibration-program / adapter-trust-program disagree, the ladder / calibration-program / adapter-trust-program wins.** Report the discrepancy and fix this doc.
+
+## Related docs
+
+- [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) — canonical deployment-class standards
+- [`calibration-program.md`](calibration-program.md) — §F / §G; canonical for physical-sensor calibration and admissibility
+- [`adapter-trust-program.md`](adapter-trust-program.md) — canonical for adapter-derived data
+- [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md) — placement → deployment class mapping; sensor variant selection
+- [`node-taxonomy.md`](node-taxonomy.md) — per-node posture tags
+- [`phase-roadmap.md`](phase-roadmap.md) — capability stages with inline deployment posture per stage
+- [`integrated-parcel-system-spec.md`](integrated-parcel-system-spec.md) — hardware role map with per-node posture summary
+- [`architecture-gaps-by-stage.md`](architecture-gaps-by-stage.md) — sibling doc, same per-stage framing for gaps
+- [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md) — four-axis versioning
+- [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md) — promotion-bar item 5 (calibration-program compliance)
+- [`../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md`](../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md) — per-phase deployment posture blocks

--- a/architecture/system/architecture-gaps-by-stage.md
+++ b/architecture/system/architecture-gaps-by-stage.md
@@ -87,6 +87,7 @@ the capability stages.
 | --- | --- | --- |
 | device identity, packet timing, buffering, and staleness rules | `current v1` | the parcel-sensing baseline is not honest without them |
 | field-hardening and deployment quality | `current v1` plus deployment maturity | a parcel claim depends on where and how the node was installed |
+| calibration program: reference instruments, burn-in, admissibility, drift | `current v1` plus deployment maturity | parcel hazard claims require readings traceable to characterized references; defined in `calibration-program.md`, gates slice promotions per `../current/pre-1.0-version-progression.md` |
 | node health, deployment metadata, and device event history | `v1.5` | these are support objects that should not break the core parcel-state contract |
 | measurement-trust and maintenance-informed trust penalties | `v1.5` | stronger trust needs separate support objects and calibration posture |
 | observed equipment / house-state signals (read-side HVAC, fan, purifier, backup power, sump) | `v1.5` | bridge objects for response curves; not the same as a full compatibility inventory |

--- a/architecture/system/calibration-program.md
+++ b/architecture/system/calibration-program.md
@@ -1,0 +1,226 @@
+# Calibration Program
+
+## Lane
+
+This is the `system/` lane document for calibration policy that applies across **every node family** in the repo. It sits alongside `node-taxonomy.md`, `sensor-placement-and-representativeness-guide.md`, and `deployment-maturity-ladder.md`.
+
+## Purpose
+
+Define the calibration policy the whole fleet inherits, so that:
+
+- every node family answers the same questions the same way (reference instruments, burn-in, drift, admissibility),
+- calibration requirements scale predictably with `deployment maturity`,
+- the hazard formula can fit coefficients only against data that has passed a documented admissibility bar.
+
+This doc is policy. Per-device execution (how a specific bench-air unit or mast-lite unit is calibrated on a given day) lives in the respective `oesis-builds/procedures/<node>/calibration.md`.
+
+## Relation to version axes
+
+Per [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md), this repo uses four axes that must not collapse. This doc touches only two of them:
+
+- **Deployment maturity** — calibration requirements scale with the ladder in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md). Higher maturity requires stricter calibration posture.
+- **Implementation status** — each requirement in this doc is labeled `implemented`, `partial`, `docs-only`, or `planned` at the end.
+
+It does **not** introduce a new axis, does **not** define capability-stage content, and does **not** promote accepted runnable slices. A slice like program-phase `v0.2` (bench-air + mast-lite) may require that its node families meet `deployment maturity v1.0` calibration posture; that dependency belongs to the promotion docs, not here.
+
+## Governing principles
+
+1. **No reading is truth without a referent.** Sensor output is a claim. A calibrated reading is a claim backed by a documented comparison against a characterized reference.
+2. **Requirements scale with deployment maturity.** Bench prototypes live under provisional calibration. First-fielded kits require real references. Trust-stage nodes require versioned calibration state. Adaptation-stage nodes require drift policy and replacement handling.
+3. **Admissibility is binary.** A reading is either admissible to the calibration dataset used for coefficient fitting, or it isn't. Partial credit creates silent fits against bring-up drift.
+4. **Policy at platform; execution per node.** This doc does not prescribe part numbers for reference instruments. Node build specs and calibration procedures name the concrete instruments that satisfy the policy for each measurand.
+5. **Traceable over perfect.** A reference instrument with a documented accuracy statement and traceability chain is more useful than a nominally more accurate instrument whose provenance cannot be verified.
+
+## Program components
+
+### A. Reference instrument program
+
+Every measurand consumed by the hazard formula must have at least one characterized reference instrument available for the deployment class in which the node operates.
+
+For each reference instrument, the program requires a file under `oesis-builds/procedures/<node>/references/<instrument>.md` with:
+
+- make, model, and serial number
+- measurand(s) and accuracy statement (e.g., "±0.2 °C, 10–40 °C")
+- traceability chain (NIST traceable where practical; otherwise document the best available chain)
+- calibration certificate reference and last verification date
+- storage conditions and permitted environmental exposure
+- known failure modes and re-verification cadence
+
+**Sharing:** a single reference instrument may serve multiple node families if it covers the measurand and deployment class of each. The reference file lives once; each using node's calibration procedure references it.
+
+**Minimum coverage for each measurand in scope**, by deployment class:
+
+| Measurand | Indoor class | Sheltered class | Outdoor class |
+|---|---|---|---|
+| Temperature | characterized reference required | characterized reference required | characterized reference required, rated for the operating envelope |
+| Relative humidity | characterized reference required | characterized reference required | characterized reference required, rated for the operating envelope |
+| Gas resistance (BME680 VOC trend) | best-available reference acceptable in `deployment maturity v0.1`; characterized reference required to progress | characterized reference required | characterized reference required |
+| PM2.5 | reference not required in current hardware lanes (no PM sensor shipped) | reference required before `weather-pm-mast` admits fits | reference required before `weather-pm-mast` admits fits |
+
+### B. Burn-in gate
+
+Sensors that require conditioning on first power-up must complete a documented burn-in window before their readings are admissible to the calibration dataset.
+
+**Current platform defaults** (subject to per-node override in the build spec, with justification):
+
+- **BME680 / BME688 (gas resistance):** 48 h burn-in minimum on first power-up. Per-packet `burn_in_complete` flag required; ingest tags observations until the window passes.
+- **SHT45 (temperature / humidity):** no burn-in requirement beyond manufacturer's standard settling; post-mounting acclimatization of 1 h recommended for meaningful rolling baselines.
+- **PM sensors (TBD per sensor family):** policy to be added when the first PM-capable node lands.
+
+**Enforcement:** the bring-up acceptance procedure for a node family must include the burn-in gate as a pass/fail item. Nodes that have not passed the gate emit readings tagged `burn_in_complete: false`; these readings are excluded by the admissibility rule below.
+
+### C. Calibration dataset admissibility
+
+A reading is admissible to the calibration dataset used for hazard-formula coefficient fitting only if all of the following hold:
+
+1. **Node identity is current.** The producing node's build version and firmware version are both recorded against a registered `parcel_id`.
+2. **Deployment maturity tier met.** The node meets at least `deployment maturity v1.0` (first fielded-kit bundle in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md)). `deployment maturity v0.1` readings may be used for prototyping analysis but are not admissible for production coefficient fits.
+3. **Deployment class honored.** The node's declared deployment class matches the physical installation, and the installation meets the power / IP / transport tier standards set for that class in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md).
+4. **Burn-in complete.** `burn_in_complete: true` at the observation's timestamp, per section B.
+5. **Reference calibration current.** The node's most recent calibration session against a characterized reference (per section A) falls within the re-verification cadence for that reference.
+6. **Placement representativeness declared.** Per [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md), the installation's class (A/B/C/D) is recorded. Class-D readings are never admissible; Class-C readings are admissible only when the hazard formula explicitly opts in for that term.
+7. **Protective fixtures verified where required.** For outdoor nodes, radiation shield or equivalent fixture has been verified against its thermal-loading acceptance test; pre-verification readings are excluded. For flood nodes, zero-reference and geometry discipline are documented.
+8. **Sensor health within bounds at observation time.** `read_failures_total` increment rate below threshold; rolling-baseline dispersion flag not `unstable`; observation age within freshness window.
+
+**Inadmissible ≠ discarded.** Inadmissible readings remain in raw logs for audit, post-hoc analysis, and outcome-label cross-checks. They do not feed coefficient fitting.
+
+#### Schema vs runtime split (decision 2026-04-19)
+
+The admissibility **decision** (the boolean outcome of the eight checks above, with reason codes) is computed in runtime/ingest, not in the canonical observation schema. This keeps the schema stable as admissibility policy evolves, allows different consumers to audit or recompute decisions, and preserves the reasoning trail.
+
+The admissibility **facts** — the static, known-at-emission-time inputs those checks consume — must appear on the canonical observation record in [`oesis-contracts`](https://github.com/lumenaut-llc/oesis-contracts) so every downstream consumer sees the same evidence without recomputing or probing the node registry.
+
+Minimum facts the observation schema must carry (cross-repo change tracked in G17):
+
+- `burn_in_complete: bool` — per section B; ingested from firmware health block or injected by ingest once the device's first-power-up window has elapsed
+- `node_calibration_session_ref: string` — opaque reference to the most recent calibration session record per section E
+- `node_deployment_maturity: enum` — one of `v0.1`, `v1.0`, `v1.5`, `v2.0` per [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md); declared in the node's build-spec §F block, carried forward on each packet
+- `node_deployment_class: enum` — one of `indoor`, `sheltered`, `outdoor` per [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md); same provenance
+- `protective_fixture_verified_at: timestamp | null` — null if not applicable; timestamp of last verified thermal-loading test (or equivalent) otherwise
+- `placement_representativeness_class: enum | null` — A/B/C/D per the placement guide; null during pre-install observations
+
+Runtime decisions produced by ingest once facts are present, attached to the normalized observation and never back-propagated to the schema:
+
+- `admissible_to_calibration_dataset: bool`
+- `admissibility_reasons: [string]` — enumerated reason codes when false (e.g., `burn_in_incomplete`, `reference_calibration_stale`, `fixture_unverified`); empty list when true
+
+Audit invariant: a normalized observation carrying `admissible_to_calibration_dataset: false` with a populated `admissibility_reasons` list is the durable artifact. Coefficient-fitting pipelines filter on the boolean; audit tooling reads the reasons to explain why a record was excluded.
+
+### D. Drift policy
+
+A device's calibration state drifts over time. The program sets three response tiers:
+
+- **Within tolerance:** periodic re-verification against the reference at the cadence named in section A. No action required.
+- **Drift detected, correctable:** when a device's offset vs. reference has grown beyond a configured threshold but below a retirement threshold, log the new correction value to the device's calibration history and version it. Subsequent readings are corrected through the versioned offset. Corresponds to `deployment maturity v1.5` calibration-versioning requirement.
+- **Drift beyond retirement threshold:** the device is retired from admissibility until repair or replacement. Readings from the flagged window are marked inadmissible and the replacement device's initial calibration is treated as a fresh session.
+
+Specific numeric thresholds are node- and measurand-specific and live in each node's calibration procedure, not in this doc.
+
+### E. Calibration log format
+
+Each calibration session produces a record with at minimum:
+
+- session timestamp (UTC)
+- node identity (build version, firmware version, unit serial)
+- reference instrument identity (per section A) and its last-verified date
+- measurand(s) exercised
+- raw reference reading(s) and raw node reading(s) for each calibration point
+- computed offset or correction, if any
+- session outcome: `pass`, `within-tolerance drift`, `correctable drift`, `retirement required`
+- operator identity
+- environmental conditions during session
+- next re-verification due date
+
+Calibration logs live alongside install metadata for the device they apply to. They are authoritative when inference or admissibility checks reference "the device's current calibration state."
+
+### F. Build-spec metadata block
+
+Every node build spec in `oesis-builds/specs/<node>/v0-X.md` must include a front-matter metadata block that declares the calibration and deployment posture the node commits to. The block is the structured contract by which node specs and calibration compliance stay greppable and — once admissibility tooling exists — machine-checkable.
+
+Minimum fields:
+
+```yaml
+---
+node_family: <string, e.g. "bench-air-node">
+build_version: <string, e.g. "v0-1">
+deployment_class: indoor | sheltered | outdoor
+deployment_maturity_target: v0.1 | v1.0 | v1.5 | v2.0
+measurands:
+  - name: <e.g. "temperature_c">
+    sensor_variant: <e.g. "sht45-filtered-pack">
+    accuracy_statement: <e.g. "±0.1 °C, 0–60 °C">
+    reference_instrument_ref: <path to file under oesis-builds/procedures/<node>/references/>
+  - name: <next measurand>
+    sensor_variant: <...>
+    accuracy_statement: <...>
+    reference_instrument_ref: <...>
+burn_in:
+  required: true | false
+  window_hours: <number, or null if not required>
+protective_fixtures:
+  - name: <e.g. "passive radiation shield">
+    acceptance_test_ref: <path to test procedure>
+transport:
+  primary: serial | wifi | lora | cellular
+  permitted_fallbacks: [<list>]
+power:
+  source: usb | dc_12v | battery_solar | mains_outdoor_psu
+  protection: [<list of protections per deployment-maturity-ladder.md>]
+calibration_program_revision: <commit hash or date of the calibration-program.md revision this spec commits against>
+---
+```
+
+Fields are validated against the deployment-class standards in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md). A build spec whose declared power source, IP rating, or transport does not match the defaults for its declared deployment class must include a justification section referencing the exception.
+
+The block is consumed by (future, planned) admissibility tooling to resolve whether a reading from a given node is admissible without re-reading the full build spec. Until the tooling ships, the block is human-readable contract — node specs are still inspectable, just not automatically enforced.
+
+### G. Promotion-bar compliance
+
+A node family's eligibility to participate in a promoted accepted-runnable slice (per [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md)) depends on the calibration posture it meets.
+
+The promotion bar for a slice names the deployment-maturity tier its node families must reach. This program's compliance bar per tier:
+
+- **`v0.1` (bench prototype):** build-spec metadata block (§F) exists; other components provisional.
+- **`v1.0` (first fielded kit):** all five §A–§E components complete for every measurand the node exposes; metadata block (§F) complete and passing validation against `deployment-maturity-ladder.md` class standards.
+- **`v1.5` (trust hardening):** §A–§F complete; calibration versioning active; drift logs in the calibration history.
+- **`v2.0` (decision-policy):** §A–§F complete; cross-node bias audit on record; retirement thresholds enforced in runtime.
+
+Slice promotion (`v0.2`, `v0.3`, …) inherits these tiers through its promotion bar. The retroactivity rule in `pre-1.0-version-progression.md` applies: already-promoted slices keep their original posture; node families moving into a new slice must meet that slice's tier.
+
+## Maturity ladder mapping
+
+Calibration posture required at each rung of [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md):
+
+| Deployment maturity | Reference instrument | Burn-in gate | Admissibility | Drift policy | Log format |
+|---|---|---|---|---|---|
+| `v0.1` (bench prototype) | Best-available acceptable; can be uncharacterized for initial software validation | Recommended, not enforced | **Not admissible** to coefficient fits | Not tracked | Informal lab notes acceptable |
+| `v1.0` (first fielded kit) | Characterized reference required per measurand, per deployment class | Enforced; `burn_in_complete` flag required | Admissible if all §C items hold | Within-tolerance cadence tracked | Structured log per §E |
+| `v1.5` (trust hardening) | v1.0 plus documented re-verification records | Enforced | Admissible; readings carry calibration-version reference | Versioned offsets; correctable-drift path enforced | Full §E + version field |
+| `v2.0` (decision-policy) | v1.5 plus cross-node consistency audits | Enforced | Admissible; plus cross-node bias checks | Retirement thresholds enforced | Full §E + version + bias-audit link |
+
+## Implementation status
+
+| Component | Status | Note |
+|---|---|---|
+| Reference instrument program (this doc) | `docs-only` | Closes policy gap in G13; concrete reference instruments per node remain to be populated |
+| Burn-in gate policy (this doc) | `docs-only` | Closes policy gap in G14; per-node enforcement requires bring-up acceptance updates |
+| Admissibility rule in ingest | `planned` | Requires new `admissible_to_calibration_dataset` field on normalized observations; not yet implemented |
+| Drift policy in runtime | `planned` | No versioned-offset pipeline today |
+| Calibration log format | `partial` | `oesis-builds/procedures/bench-air-node/calibration.md` has a procedure template; §E fields not all captured |
+
+## Gap register references
+
+- **G13** — populate at least one characterized reference instrument per measurand per deployment class (execution of §A).
+- **G14** — enforce burn-in gate in bring-up acceptance (execution of §B).
+- **G12** — mast-lite must meet this calibration program at `deployment maturity v1.0` before Milestone 2 promotion; covered by the mast-lite build spec and calibration procedure once written.
+- **P0** gates in [`../software/inference-engine/hazard-formula-v1-phase1.md`](../../software/inference-engine/hazard-formula-v1-phase1.md) are the hazard-formula-side view of this program; admissibility rule in §C is what those gates are gating.
+
+## Related docs
+
+- [`version-and-promotion-matrix.md`](version-and-promotion-matrix.md) — canonical axes
+- [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) — maturity tiers this program scales with
+- [`node-taxonomy.md`](node-taxonomy.md) — node families that inherit this program
+- [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md) — placement classes used in admissibility
+- [`../../software/inference-engine/hazard-formula-v1.md`](../../software/inference-engine/hazard-formula-v1.md) — the formula whose coefficient fits depend on admissible data
+- [`../../software/inference-engine/hazard-formula-v1-phase1.md`](../../software/inference-engine/hazard-formula-v1-phase1.md) — Phase 0 prerequisites that this program operationalizes
+- Cross-repo: per-node calibration procedures at [`oesis-builds/procedures/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/procedures) and build specs at [`oesis-builds/specs/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/specs)

--- a/architecture/system/cross-repo-architecture.md
+++ b/architecture/system/cross-repo-architecture.md
@@ -160,13 +160,29 @@ metadata. The public site renders this without reading raw specs files.
 - Source: `artifacts/public-content-bundle/public-content-bundle.json`
 - Consumer: `oesis-public-site` via `src/generated/publicContentBundle.ts`
 
+## Calibration and admissibility across repos
+
+Calibration posture and admissibility decisions span all four repositories (plus `oesis-builds` for hardware procedures). The chain must be navigable end-to-end.
+
+| Repo | What it owns for calibration / admissibility |
+|---|---|
+| **oesis-program-specs** | Policy — [`architecture/system/calibration-program.md`](calibration-program.md) (§A–§G) and [`architecture/system/adapter-trust-program.md`](adapter-trust-program.md); promotion-bar item 5 in [`../current/pre-1.0-version-progression.md`](../current/pre-1.0-version-progression.md) |
+| **oesis-contracts** | Schema facts — observation record carries `burn_in_complete`, `node_calibration_session_ref`, `node_deployment_maturity`, `node_deployment_class`, `protective_fixture_verified_at`, `placement_representativeness_class` (physical sensors), plus adapter-derived equivalents. Admissibility **decision** fields do not live here. |
+| **oesis-runtime** | Admissibility decision — ingest computes `admissible_to_calibration_dataset` + `admissibility_reasons` on normalized observations; inference consumes but does not override |
+| **oesis-builds** | Execution — per-node build specs (§F metadata block), per-node calibration procedures, per-parcel verification records under `procedures/<node>/` |
+
+The schema-vs-runtime split (facts in schema; decision in runtime) is a deliberate architectural decision; see `calibration-program.md` §C "Schema vs runtime split". Schema changes required for this are tracked as v0.1 gap register entry G17.
+
 ## Adding a new capability
 
 When extending the system (new node family, new observation type, new
 governance surface), the work spans repos in this order:
 
 1. **Specs first:** Define the schema, create a canonical example, update the
-   relevant contract README, and place it in the correct lane
+   relevant contract README, and place it in the correct lane. For new node
+   or adapter families, confirm a calibration-program or adapter-trust-program
+   §F metadata block is declared in the node's build spec before schema
+   changes land.
 2. **Runtime second:** Implement the normalizer/inference/platform code, add
    the example to the correct asset lane, write acceptance tests
 3. **Hardware if applicable:** Design the node, write the serial-JSON contract,

--- a/architecture/system/deployment-maturity-ladder.md
+++ b/architecture/system/deployment-maturity-ladder.md
@@ -107,6 +107,44 @@ No node should be described as deployed or field-ready unless the repo documents
 - visible field status indicator if practical
 - spare-parts and replacement posture
 
+## Deployment-class standards
+
+The three deployment classes named in [`sensor-placement-and-representativeness-guide.md`](sensor-placement-and-representativeness-guide.md) (Indoor, Sheltered, Outdoor) carry platform-level standards for power, enclosure IP rating, and transport. Each node build spec declares its deployment class; the standards below are the defaults. A node may deviate from a default only with an explicit justification documented in its build spec (and where warranted, a gap register entry).
+
+These standards are independent of the capability-stage and accepted-slice axes. They belong to the deployment-maturity ladder because field-hardening is the axis they gate.
+
+### Power source tier by deployment class
+
+| Deployment class | Power source default | Minimum protection | Runtime floor |
+|---|---|---|---|
+| Indoor | USB from protected supply, or low-voltage DC from adapter | Reverse-polarity protection where applicable; avoid daisy-chain power sharing | Defined by the installation's wall outlet reliability |
+| Sheltered | 12 V regulated DC from an outdoor-rated adapter, or USB if the mount is within an enclosed space | Surge protection on entry; fused input; strain relief on cable path | 24 h minimum buffering or local store where ingest loss is consequential |
+| Outdoor | Battery + solar with documented runtime floor, or mains with outdoor-rated PSU routed through conduit | Surge + transient + weather protection on entry; fused; sealed connectors | 72 h runtime floor under worst-case solar; retention of last observations through power events |
+
+Pre-v0.1 bench bring-up may deviate (USB on a dev board is fine). Promotion to `deployment maturity v1.0` requires matching the class default or documenting why not.
+
+### Enclosure IP rating tier by deployment class
+
+| Deployment class | Enclosure rating floor | Typical features |
+|---|---|---|
+| Indoor | Not rated / IP20 acceptable | Dust-ingress management if near HVAC return; no water handling required |
+| Sheltered | IP44 minimum | Rain-splash resistant; venting or membrane vent to prevent condensation; drip-path controlled |
+| Outdoor | IP54 minimum for passive scenarios; IP65+ for exposed mast installations | Cable glands; venting via membrane; corrosion-aware hardware; UV-stable plastics |
+
+Where a node family requires a radiation shield, weather cowl, or other protective fixture (for example, an outdoor SHT45 mount), the fixture is treated as part of the enclosure for admissibility. Per [`calibration-program.md`](calibration-program.md) §C, readings taken before the protective fixture is verified against its acceptance test are inadmissible to the calibration dataset.
+
+### Transport tier by deployment class
+
+Short-term v0.1 posture is serial-only (see gap register G3). This table sets the long-term policy once transport lanes widen:
+
+| Deployment class | Permitted transports | Notes |
+|---|---|---|
+| Indoor | Serial (for v0.1 floor); Wi-Fi; wired LAN | Wi-Fi credentials and authorization are governed by the ingest-side design note tracked in G2 |
+| Sheltered | Serial; Wi-Fi where the mount is within reliable coverage; LoRa permitted | Same authorization requirements as Indoor |
+| Outdoor | Serial during bring-up only; Wi-Fi where coverage is verified; LoRa or cellular permitted for parcels beyond Wi-Fi reach | Transport choice must preserve packet-lineage semantics; no transport may reshape `oesis.bench-air.v1` payload |
+
+Transport choice does not alter the packet schema or the admissibility rule. A packet delivered over LoRa is held to the same schema and integrity requirements as one delivered over serial.
+
 ## Node-family maturity map
 
 | Node family | Current maturity posture | First honest maturity target | Key gap to close |

--- a/architecture/system/integrated-parcel-system-spec.md
+++ b/architecture/system/integrated-parcel-system-spec.md
@@ -117,6 +117,24 @@ It should not inherit a deployability claim from the rest of the parcel kit.
 | Power / outage (planned) | `power-outage-node` | service / utility entry | mains and backup posture for continuity | **Capability `v1.5` bridge** — taxonomy only until built |
 | Freeze (planned) | `freeze-node` | crawlspace, garage, pipe-risk zones | cold-climate hazard evidence | **Geography-gated** — taxonomy only until built |
 
+### Deployment posture per node
+
+Posture defaults are inherited from the deployment-class standards in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md); each node's authoritative declaration lives in the §F metadata block of its `oesis-builds/specs/<node>/v0-X.md` spec per [`calibration-program.md`](calibration-program.md) §F. This table summarizes the defaults for quick reference.
+
+| Node family | Deployment class | Power source | IP tier | Transport floor | Protective fixtures required |
+| --- | --- | --- | --- | --- | --- |
+| `bench-air-node` | indoor | USB | none / IP20 | serial | none |
+| `mast-lite` | sheltered | 12V-DC or USB from indoor | IP44 | serial → Wi-Fi | radiation shield |
+| `weather-pm-mast` | outdoor | mains with outdoor-rated PSU | IP65 | Wi-Fi | radiation shield + PM airflow module |
+| `flood-node` | outdoor | battery + solar, or hardened mains | IP65 | serial → LoRa | rigid mount + zero-reference + staff gauge |
+| `thermal-pod` | outdoor (research) | mains | IP54 | Wi-Fi | hooded enclosure; privacy-reviewed field-of-view |
+| `indoor-response-node` | indoor | USB | none / IP20 | Wi-Fi | none |
+| `power-outage-node` | indoor | battery-backed | none / IP20 | Wi-Fi or LoRa | intrinsic — device must outlive the mains outage it observes |
+| `circuit-monitor` | mains-adjacent (indoor panel) | low-power from measured circuit | electrical enclosure (IP20) | Wi-Fi | electrical-code-compliant CT clamp installation |
+| `freeze-node` | sheltered | 12V-DC expected | IP44 | serial → Wi-Fi | TBD until build spec lands |
+
+Adapter-derived surfaces (`equipment-state-adapter`, passive inference methods) do not have physical posture and are governed instead by [`adapter-trust-program.md`](adapter-trust-program.md); they carry a §F block declaring source authority, contract version, and tier.
+
 ## Singular system topology
 
 ### Parcel identity layer
@@ -146,6 +164,17 @@ Minimum registry fields:
 - `last_seen_at`
 
 The registry is also where the repo should eventually attach deployment-maturity facts such as enclosure revision, service posture, storage class, and replacement history rather than quietly leaving those decisions out of the architecture.
+
+### Calibration and admissibility layer
+
+The calibration state referenced in the node registry is produced and governed by the calibration program at platform level (see [`calibration-program.md`](calibration-program.md) for physical sensors and [`adapter-trust-program.md`](adapter-trust-program.md) for Tier 1 / Tier 2 adapter-derived data).
+
+Two concepts are distinct and both belong to this layer:
+
+- **Calibration posture** — what the node is committed to per its §F build-spec metadata block: deployment class, deployment-maturity target, reference instruments, burn-in parameters, protective fixtures. A static declaration stored in the build spec; inherited on every observation.
+- **Admissibility decision** — the runtime outcome of the eight-point check in calibration-program §C (or the parallel check in adapter-trust-program §C for adapters). Computed on normalized observations; carries reason codes; filters which readings can train coefficients or feed inference.
+
+The observation record carries the **facts** required for admissibility (burn-in state, calibration session reference, deployment class, protective-fixture verification, etc.); runtime computes the **decision**. See the v0.1 gap register entry G17 for the cross-repo schema change this requires.
 
 ### Evidence transport layer
 
@@ -337,6 +366,8 @@ This is better treated as a `deployment maturity v1.5` target than a default `v1
 - install metadata standard that inference can trust
 - shared field-hardening checklist used across node families
 - explicit maturity labeling so controlled-review docs do not overstate deployability
+- calibration program §F build-spec metadata block populated for every active node family
+- admissibility tooling wiring in runtime (ingest produces the decision per calibration-program §C; inference consumes it)
 
 ## Recommended implementation decisions
 

--- a/architecture/system/node-taxonomy.md
+++ b/architecture/system/node-taxonomy.md
@@ -21,15 +21,17 @@ Give one repo-wide vocabulary for **hardware node families**, **geography-gated 
 
 ## Current-truth hardware (accepted reference path today)
 
+Per-family posture tag: **(deployment-class / power tier / IP tier / transport floor)**. Tags summarize the defaults declared in [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) "Deployment-class standards"; per-node build specs in `oesis-builds/specs/<node>/v0-X.md` carry the authoritative §F metadata block per [`calibration-program.md`](calibration-program.md) §F.
+
 | Identifier | Role | Notes |
 | --- | --- | --- |
-| `bench-air-node` | Indoor or sheltered bench reference; `oesis.bench-air.v1` lineage | Proven end-to-end ingest → parcel view for this family |
+| `bench-air-node` | Indoor or sheltered bench reference; `oesis.bench-air.v1` lineage | Proven end-to-end ingest → parcel view for this family. Posture: **(indoor / USB / IP20 / serial)** |
 
 ## Next-promotion kit hardware (not the same as “fully proven”)
 
 | Identifier | Role | Notes |
 | --- | --- | --- |
-| `mast-lite` | First sheltered-outdoor reference; same packet lineage as bench-air | Architecturally in scope; runtime normalization and field validation are **partial** until the `v0.2` promotion bar in `../current/pre-1.0-version-progression.md` is met |
+| `mast-lite` | First sheltered-outdoor reference; same packet lineage as bench-air | Architecturally in scope; runtime normalization and field validation are **partial** until the `v0.2` promotion bar in `../current/pre-1.0-version-progression.md` is met. Posture: **(sheltered / 12V-DC or USB from indoor / IP44 / serial→Wi-Fi)**; radiation shield required as protective fixture per calibration-program §C |
 
 ## Geography-gated and second-wave hardware modules
 
@@ -37,15 +39,15 @@ Attach only when parcel risk, region, and use case justify them. None of these a
 
 | Identifier | Role | Typical staging |
 | --- | --- | --- |
-| `flood-node` | Low-point runoff depth and rise-rate evidence | Optional hazard module; ingest and inference implemented (`flood.low_point.snapshot`) |
-| `weather-pm-mast` | Richer outdoor PM, wind, rainfall | Second-wave outdoor lane; ingest and inference implemented (`air.pm.snapshot`) |
-| `freeze-node` | Cold-climate pipe-risk and exposed-space thermal evidence | Planned geography module; not required for warm-climate pilots |
+| `flood-node` | Low-point runoff depth and rise-rate evidence | Optional hazard module; ingest and inference implemented (`flood.low_point.snapshot`). Posture: **(outdoor / battery+solar or hardened mains / IP65 / serial→LoRa)**; rigid mount + zero-reference required as protective fixture |
+| `weather-pm-mast` | Richer outdoor PM, wind, rainfall | Second-wave outdoor lane; ingest and inference implemented (`air.pm.snapshot`). Posture: **(outdoor / mains with outdoor-rated PSU / IP65 / Wi-Fi)**; PM airflow module + radiation shield required |
+| `freeze-node` | Cold-climate pipe-risk and exposed-space thermal evidence | Planned geography module; not required for warm-climate pilots. Posture: **(sheltered / 12V-DC / IP44 / serial→Wi-Fi)** expected; final posture confirmed when build spec lands |
 
 ## Research- or privacy-gated hardware
 
 | Identifier | Role | Notes |
 | --- | --- | --- |
-| `thermal-pod` | Fixed-scene derived thermal context | R&D lane; keep outside default pilot until contract, usefulness, and retention posture are reviewed |
+| `thermal-pod` | Fixed-scene derived thermal context | R&D lane; keep outside default pilot until contract, usefulness, and retention posture are reviewed. Posture: **(research / mains / IP54 / Wi-Fi)**; declare deployment-maturity target below `v1.0` until scene + privacy posture clears |
 
 ## Capability-stage v1.5 bridge (planned hardware and adapters)
 
@@ -56,10 +58,10 @@ It is to collect the minimum surfaces needed to model how the house responds to 
 
 | Identifier | Kind | Minimum intent |
 | --- | --- | --- |
-| `indoor-response-node` | Hardware family (planned) | Indoor PM2.5, indoor temperature, indoor RH — lets the system see whether the house is buffering occupants from outdoor forcing |
-| `power-outage-node` | Hardware family or adapter (planned) | Mains up/down and backup-power posture — continuity and resilience floor during disruption |
-| `equipment-state-adapter` | Non-node or adapter surface | Read-side HVAC mode, fan, recirculation vs fresh air, purifier, shade/window, sump/pump where available |
-| `circuit-monitor` | Hardware family (implemented) | Non-invasive current-draw monitoring node using split-core CT clamps and PZEM-004T/016. Monitors HVAC and sump pump circuits for operating state, power draw, and cycle timing. Equipment-state adapter that feeds `hvac_mode`, `sump_state`, `equipment_running`, and power draw data into house-state at HIGH confidence. Optional equipment-state module -- not part of default Tier 1-2 parcel kit. See [`circuit-monitor/README.md`](https://github.com/lumenaut-llc/oesis-hardware/blob/main/circuit-monitor/README.md) |
+| `indoor-response-node` | Hardware family (planned) | Indoor PM2.5, indoor temperature, indoor RH — lets the system see whether the house is buffering occupants from outdoor forcing. Posture: **(indoor / USB / IP20 / Wi-Fi)** |
+| `power-outage-node` | Hardware family or adapter (planned) | Mains up/down and backup-power posture — continuity and resilience floor during disruption. Posture: **(indoor / battery-backed / IP20 / Wi-Fi or LoRa)**; battery-backed power is intrinsic to the use case — continuity-monitor that loses power is useless |
+| `equipment-state-adapter` | Non-node or adapter surface | Read-side HVAC mode, fan, recirculation vs fresh air, purifier, shade/window, sump/pump where available. Posture: **adapter (no physical power of its own)**; governed by [`adapter-trust-program.md`](adapter-trust-program.md) rather than calibration-program |
+| `circuit-monitor` | Hardware family (implemented) | Non-invasive current-draw monitoring node using split-core CT clamps and PZEM-004T/016. Monitors HVAC and sump pump circuits for operating state, power draw, and cycle timing. Equipment-state adapter that feeds `hvac_mode`, `sump_state`, `equipment_running`, and power draw data into house-state at HIGH confidence. Optional equipment-state module -- not part of default Tier 1-2 parcel kit. Posture: **(mains-adjacent / low-power from measured circuit / IP20 electrical enclosure / Wi-Fi)**; Tier 3 direct measurement per this doc's tiered acquisition model. See [`circuit-monitor/README.md`](https://github.com/lumenaut-llc/oesis-hardware/blob/main/circuit-monitor/README.md) |
 | `action-log` | Support object | Household or building actions (mode changes, purifier run, drain clearing, barrier install, backup activation) with timestamps and targets |
 | `outcome-log` / response verification | Support object | Whether actions improved observed conditions over defined windows (for example 30–90 minutes for smoke-related PM response) |
 | `building-and-site-metadata-surface` | Parcel-context extensions | Orientation, roof/color, shading, tree canopy, impervious area, low points, drainage, vents, filter path — part of response interpretation, not decorative metadata |
@@ -122,12 +124,30 @@ Prefer public data, shared reports, and selected instrumentation over universal 
 4. **v2 / v2.5:** bounded guidance, then compatibility inventory and bounded controls.
 5. **v4:** route and neighborhood resilience surfaces.
 
+## Per-node part sheets
+
+For one-page-per-node aggregator pages that pull together architecture, calibration, cross-repo links, and gap-register entries for each family, see [`parts/`](parts/):
+
+- [`parts/bench-air-node.md`](parts/bench-air-node.md)
+- [`parts/mast-lite.md`](parts/mast-lite.md)
+- [`parts/flood-node.md`](parts/flood-node.md)
+- [`parts/weather-pm-mast.md`](parts/weather-pm-mast.md)
+- [`parts/thermal-pod.md`](parts/thermal-pod.md)
+- [`parts/circuit-monitor.md`](parts/circuit-monitor.md)
+
+Part sheets aggregate via links; this taxonomy doc remains canonical for posture tags and acquisition-tier placement.
+
 ## Related docs
 
 - `version-and-promotion-matrix.md`
 - `integrated-parcel-system-spec.md`
 - `deployment-maturity-ladder.md`
+- `calibration-program.md` — calibration posture each node family must meet at its deployment-maturity tier; promotion-bar compliance in §G
+- `adapter-trust-program.md` — parallel policy for adapter-derived data (Tier 1 / Tier 2, plus circuit-monitor as Tier 3 direct)
+- `sensor-placement-and-representativeness-guide.md`
 - `architecture-gaps-by-stage.md`
+- `architectural-choices-by-stage.md` — master cross-phase summary
 - `phase-roadmap.md`
+- `parts/README.md` — per-node aggregator pages
 - [`parcel-context-schema.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/parcel-context-schema.md)
 - [`v0.1/README.md`](https://github.com/lumenaut-llc/oesis-hardware/blob/main/v0.1/README.md)

--- a/architecture/system/parts/README.md
+++ b/architecture/system/parts/README.md
@@ -1,0 +1,65 @@
+# Node part sheets
+
+## Purpose
+
+One-page-per-node aggregator pages. Each part sheet pulls together what lives in canonical docs scattered across the repo: architecture posture (from `node-taxonomy.md` and `integrated-parcel-system-spec.md`), deployment-class defaults (from `deployment-maturity-ladder.md`), calibration posture (from `calibration-program.md`), adapter-trust posture where applicable (from `adapter-trust-program.md`), cross-repo references (design in oesis-hardware, build in oesis-builds, runtime in oesis-runtime), gap-register entries, and per-phase role evolution.
+
+## What these pages are — and what they aren't
+
+Part sheets **aggregate via links**. They cite canonical sources; they do not restate cell values. Per [`../../../meta/doc-discipline.md`](../../../meta/doc-discipline.md) Rule 2, if a part sheet and its cited source disagree, the source wins — fix the sheet.
+
+Part sheets are **not**:
+
+- Build guides (those live in [oesis-hardware](https://github.com/lumenaut-llc/oesis-hardware))
+- Build specs (those live in [oesis-builds/specs/](https://github.com/lumenaut-llc/oesis-builds/tree/main/specs))
+- Runtime normalizers (those live in [oesis-runtime](https://github.com/lumenaut-llc/oesis-runtime))
+- The taxonomy itself ([`../node-taxonomy.md`](../node-taxonomy.md))
+
+They are the answer to "give me one page that tells me the architectural story of `<node>` across all repos and version stages."
+
+## Pages in this directory
+
+| Node family | Type | Deployment class | Maturity | Stage of introduction |
+|---|---|---|---|---|
+| [`bench-air-node.md`](bench-air-node.md) | Physical sensor | indoor | `v0.1` → targeting `v1.0` | v0.1 (current truth) |
+| [`mast-lite.md`](mast-lite.md) | Physical sensor | sheltered | targeting `v1.0` | v0.2 (next promotion; G12 blocker) |
+| [`flood-node.md`](flood-node.md) | Physical sensor | outdoor | targeting `v1.0` | v0.3 |
+| [`weather-pm-mast.md`](weather-pm-mast.md) | Physical sensor | outdoor | targeting `v1.5` | v1.0 (second wave) |
+| [`thermal-pod.md`](thermal-pod.md) | Physical sensor | outdoor (research-gated) | intentionally < `v1.0` | research lane |
+| [`circuit-monitor.md`](circuit-monitor.md) | Tier 3 adapter | mains-adjacent | targeting `v1.5` | capability-stage `v1.5` |
+
+## When to update a part sheet
+
+Update when:
+
+- A new build version of the node lands (add a row to the page's version-evolution table, link the new spec).
+- A deployment-class or maturity change is proposed (cite the decision; do not change the values without updating upstream).
+- A new gap-register entry involves the node (add to cross-repo link map).
+- A per-phase role changes (amend the phase table).
+
+Do **not** update to restate values that live in `deployment-maturity-ladder.md`, `calibration-program.md`, or other canonical sources. Those updates happen upstream; the part sheet inherits them via citation.
+
+## Template
+
+New part sheets follow the same shape:
+
+1. One-line summary
+2. Deployment posture (citing ladder + role-map row)
+3. Version evolution table
+4. Calibration posture (citing calibration-program or adapter-trust-program)
+5. Role in each program-phase
+6. Cross-repo link map
+7. Known gotchas
+8. Related docs
+
+When adding a new part sheet, start from the bench-air-node sheet or mast-lite sheet (most complete) and adapt.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) — canonical taxonomy and posture tags
+- [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node" table — source of per-node posture values
+- [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) — class / power / IP / transport defaults
+- [`../calibration-program.md`](../calibration-program.md) — physical-sensor calibration policy
+- [`../adapter-trust-program.md`](../adapter-trust-program.md) — adapter-derived trust policy
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) — master cross-phase summary
+- [`../../../release/v.0.1/v0.1-gap-register.md`](../../../release/v.0.1/v0.1-gap-register.md) — G1–G24 gap tracking

--- a/architecture/system/parts/bench-air-node.md
+++ b/architecture/system/parts/bench-air-node.md
@@ -1,0 +1,76 @@
+# bench-air-node
+
+## One-line summary
+
+Indoor air sensor node for parcel-operator-local smoke and heat evidence; the reference lineage for the `oesis.bench-air.v1` packet family. Current-truth hardware; the only node family proven end-to-end through the software stack today.
+
+## Deployment posture
+
+Values cited from canonical sources; do not edit here if upstream changes.
+
+- **Deployment class:** `indoor` — per [`../node-taxonomy.md`](../node-taxonomy.md) current-truth table and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node" row.
+- **Power tier:** `USB` — per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) Deployment-class standards (indoor row).
+- **IP tier:** `IP20` (none required) — per ladder indoor row.
+- **Transport tier:** `serial` (v0.1 floor per gap G3); Wi-Fi permitted in later lanes.
+- **Protective fixtures:** none required (indoor-only).
+- **Sensor variants:**
+  - Temperature + humidity: SHT45 per [`../sensor-placement-and-representativeness-guide.md`](../sensor-placement-and-representativeness-guide.md) Sensor variant selection principles; unfiltered variant acceptable for indoor placement.
+  - Gas resistance: BME680 per decision [`oesis-builds/decisions/bench-air-node/2026-04-bme680-authoritative.md`](https://github.com/lumenaut-llc/oesis-builds/blob/main/decisions/bench-air-node/2026-04-bme680-authoritative.md).
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` | shipped (v0.1 reference) | [`oesis-builds/specs/bench-air-node/v0-1.md`](https://github.com/lumenaut-llc/oesis-builds/blob/main/specs/bench-air-node/v0-1.md) | §F front-matter block missing — tracked as G16; proposal at [`../../../meta/proposals/oesis-builds-calibration-program-integration.md`](../../../meta/proposals/oesis-builds-calibration-program-integration.md) Edit 4 |
+| `v0-2` (planned) | not yet drafted | tbd | Forward version to carry any schema / wiring / firmware changes that arise from v0.2 promotion work |
+
+## Calibration posture
+
+Governed by [`../calibration-program.md`](../calibration-program.md) (physical-sensor program).
+
+- **Deployment-maturity target:** `v1.0` (first fielded kit) — required by v0.2 promotion bar per [`../../current/pre-1.0-version-progression.md`](../../current/pre-1.0-version-progression.md) item 5, with retroactivity rule: v0.1 sign-off is not reopened, but bench-air must reach v1.0 posture as part of v0.2.
+- **Reference instruments:** not yet populated under `oesis-builds/procedures/bench-air-node/references/` — placeholder only. Tracked as **G13**.
+- **Burn-in:** 48 h required for BME680 per calibration-program §B. Not yet enforced in bring-up acceptance. Tracked as **G14**.
+- **Admissibility status:** v0.1 readings are **not admissible** to calibration-dataset coefficient fitting per §C. Admissibility becomes possible after v1.0 posture is reached (§F block populated, reference instruments present, burn-in gate enforced, protective-fixture requirements satisfied — all n/a for indoor).
+- **§F build-spec metadata block:** planned — proposal at [`../../../meta/proposals/oesis-builds-calibration-program-integration.md`](../../../meta/proposals/oesis-builds-calibration-program-integration.md) Edit 4.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| `v0.1` | sole node; one parcel, one pipeline, one view | Frozen reference slice per [`../../current/minimum-functioning-v0.1.md`](../../current/minimum-functioning-v0.1.md). Deployment-maturity `v0.1` acceptable. Serial-only transport. |
+| `v0.2` | indoor half of the two-node kit | Paired with mast-lite for sheltered outdoor. Must reach deployment-maturity `v1.0` per promotion bar (retroactivity rule applies). |
+| `v0.3` | unchanged from v0.2 | Flood-node lands alongside; bench-air role unchanged. |
+| `v0.4` | indoor node within multi-node registry | Stronger registry-driven lifecycle per [`../../current/milestone-roadmap.md`](../../current/milestone-roadmap.md) Milestone 4 context. |
+| `v0.5` | unchanged from v0.4 | Governance-gated shared-layer contribution possible per gap G22. |
+| `v1.0` (pre-1.0 ladder) | same role; now at fleet-wide deployment-maturity `v1.0` | §F, §A, §B, §C, §E all complete per calibration-program §G. |
+| `v1.5` (capability-stage bridge) | unchanged physical role; indoor-response-node may complement it | indoor-response-node adds indoor PM2.5 / T / RH; bench-air remains the primary indoor air source for smoke/heat. |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) current-truth; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node" |
+| Hardware design | [oesis-hardware/bench-air-node/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/bench-air-node) (build-guide, wiring, serial-json-contract, firmware) |
+| Build spec (pinned) | [oesis-builds/specs/bench-air-node/v0-1.md](https://github.com/lumenaut-llc/oesis-builds/blob/main/specs/bench-air-node/v0-1.md) |
+| Build procedures | [oesis-builds/procedures/bench-air-node/](https://github.com/lumenaut-llc/oesis-builds/tree/main/procedures/bench-air-node) (bring-up, calibration, cross-check, stress-test) |
+| Build guide (practical) | [oesis-builds/GUIDE.md](https://github.com/lumenaut-llc/oesis-builds/blob/main/GUIDE.md) |
+| Runtime normalizer | [oesis-runtime: `oesis.ingest.normalize_packet`](https://github.com/lumenaut-llc/oesis-runtime) |
+| Packet schema | `oesis.bench-air.v1` — [oesis-contracts/v0.1/node-observation-schema.md](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/node-observation-schema.md) |
+| Gap register entries | **G13** (reference instruments), **G14** (burn-in gate), **G16** (§F block), **G23** (config provenance) |
+
+## Known gotchas
+
+- **BME680 vs BME688** — BOM CSV defect resolved via decision [`oesis-builds/decisions/bench-air-node/2026-04-bme680-authoritative.md`](https://github.com/lumenaut-llc/oesis-builds/blob/main/decisions/bench-air-node/2026-04-bme680-authoritative.md).
+- **48h burn-in** — BME680 gas-resistance readings are unstable for the first 24–48 h. Ingest tagging via `burn_in_complete: false` is planned (G14) but not yet wired.
+- **Thermal-bleed between BME680 and SHT45** — spec requires ≥ 2 cm separation; slipping this contaminates the gas-resistance rolling baseline by the temperature sensor's self-heating.
+- **Wikipedia-style entity reference:** [oesis-wiki BME680 entity page](https://github.com/lumenaut-llc/oesis-wiki/blob/main/wiki/entities/bme680.md), [oesis-wiki SHT45 entity page](https://github.com/lumenaut-llc/oesis-wiki/blob/main/wiki/entities/sht45.md).
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md)
+- [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md)
+- [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md)
+- [`../calibration-program.md`](../calibration-program.md)
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) row v0.1
+- [`mast-lite.md`](mast-lite.md) — sibling node that lands at v0.2

--- a/architecture/system/parts/circuit-monitor.md
+++ b/architecture/system/parts/circuit-monitor.md
@@ -1,0 +1,80 @@
+# circuit-monitor
+
+## One-line summary
+
+**Tier 3 direct-measurement adapter** (not a parcel-sensing hardware node in the taxonomy sense). Non-invasive current-draw monitoring via CT clamps on HVAC and sump circuits; produces HIGH-confidence equipment-state signals for house-state reasoning at capability-stage v1.5. Governed by the **adapter-trust program**, not the calibration program. Optional equipment-state module — not part of the default Tier 1-2 parcel kit.
+
+## Deployment posture
+
+This node has a **dual posture**: it is an adapter (Tier 3) by how it feeds evidence into inference, and a physical device by how it is installed. Both postures are declared.
+
+### Adapter posture (per [`../adapter-trust-program.md`](../adapter-trust-program.md) §F)
+
+- **Tier:** `tier_3_direct` — direct measurement via CT clamp current.
+- **Source authority:** the PZEM-004T/016 module reading the CT clamp; pinned contract version = `pzem-004t-v3-serial`.
+- **Cross-check reference:** none required — Tier 3 is the highest tier; no higher source to cross-check against.
+
+### Physical posture (per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) Deployment-class standards and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node")
+
+- **Deployment class:** `mains-adjacent` (indoor, inside or near electrical panel).
+- **Power tier:** low-power from measured circuit.
+- **IP tier:** electrical-enclosure IP20.
+- **Transport tier:** Wi-Fi.
+- **Protective fixtures:** electrical-code-compliant CT clamp installation — licensed electrician required in many jurisdictions.
+- **Sensor variants:** PZEM-004T or PZEM-016 module + split-core CT clamps.
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` (planned) | not yet drafted | `oesis-builds/specs/adapters/circuit-monitor/v0-1.md` — **does not exist** | Spec lives under `specs/adapters/` subtree (per [`../adapter-trust-program.md`](../adapter-trust-program.md) §F) rather than `specs/<node>/`. Skeleton proposal at [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) Skeleton 5. |
+
+Hardware at [oesis-hardware/circuit-monitor/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/circuit-monitor).
+
+## Trust posture
+
+Governed by [`../adapter-trust-program.md`](../adapter-trust-program.md) — **not** calibration-program (this is a deliberate architectural split: calibration-program is for physical-sensor drift; adapter-trust-program is for source-authority and contract-version discipline).
+
+- **Deployment-maturity target:** `v1.5` (trust hardening).
+- **Source authority file:** `oesis-builds/procedures/adapters/circuit-monitor/source.md` — to author.
+- **Onboarding gate:** installation-code-compliance acceptance test; initial verification window 24 h.
+- **Cross-check:** none required per tier (Tier 3 is the reference).
+- **Drift policy:** schema-drift detection on PZEM firmware version changes; cross-adapter consistency audits when multiple circuit-monitors exist per parcel.
+- **Credential model:** none (direct serial; no cloud auth).
+- **Admissibility status:** not admissible today (no build spec, no source authority file, no onboarding verification).
+- **§F build-spec metadata block:** planned — skeleton in the proposal.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| All pre-1.0 slices and `v1.0` | **not in scope** | Default Tier 1–2 parcel kit does not include circuit-monitor. |
+| `v1.5` (capability-stage bridge) | **Tier 3 equipment-state source** | Feeds `hvac_mode`, `sump_state`, `equipment_running`, and power draw into house-state. Highest-confidence tier per [`../node-taxonomy.md`](../node-taxonomy.md) tiered acquisition model. |
+| `v2` (guidance) / `v2.5` (bounded controls) | unchanged role as evidence source | Control-side adapters (Matter / Home Assistant / BACnet) are separate Tier 2 adapters; circuit-monitor remains read-side. |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) `v1.5` bridge table; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node" |
+| Hardware design | [oesis-hardware/circuit-monitor/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/circuit-monitor) |
+| Build spec | **missing** — skeleton in [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) at `specs/adapters/circuit-monitor/v0-1.md` path |
+| Runtime normalizer | `oesis.ingest.v1_0.normalize_circuit_monitor_packet` (implemented per [`../../current/implementation-posture.md`](../../current/implementation-posture.md) "Additional normalization") |
+| Packet schema | `oesis.circuit-monitor.v1` → `equipment.circuit.snapshot` — [oesis-contracts/v1.0/circuit-monitor-observation-schema.md](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v1.0/circuit-monitor-observation-schema.md) |
+| Equipment-state bridge | [oesis-contracts/v1.0/schemas/equipment-state-observation.schema.json](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v1.0/schemas/equipment-state-observation.schema.json) |
+| Gap register entries | **G18** (adapter-trust execution — circuit-monitor is one of the adapters this gap covers), **G17** (adapter-derived observation-schema facts) |
+
+## Known gotchas
+
+- **Electrical code compliance is a hard prerequisite.** Installation on live mains circuits requires licensed electrician in many jurisdictions. This is a deployment gate, not a spec item.
+- **Adapter vs physical-sensor confusion.** Circuit-monitor blurs the line. By the taxonomy it is an adapter (Tier 3, equipment-state). By installation it is a physical device that consumes mains-adjacent power. Its §F metadata block carries both an adapter section and a `physical_posture` section.
+- **Optional, not default.** Do not treat circuit-monitor as required for a v1.5 parcel kit. Tier 1 (passive inference) and Tier 2 (cloud API) are acceptable alternatives for `hvac_mode` and similar fields; Tier 3 is added selectively where HIGH confidence matters (for example smoke-protect verification).
+- **Recirculate vs fresh-air indistinguishable** from current draw alone — classification collapses to "fan on" without damper-position knowledge. Tier 1 (thermal-slope inference) shares this limitation.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) `v1.5` bridge tiered acquisition model
+- [`../adapter-trust-program.md`](../adapter-trust-program.md) — governing policy for this part
+- [`../../v1.5/house-state-and-verification-model.md`](../../v1.5/house-state-and-verification-model.md) — where circuit-monitor evidence feeds
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) row v1.5
+- [`thermal-pod.md`](thermal-pod.md) — other research/specialty-lane part sheet

--- a/architecture/system/parts/flood-node.md
+++ b/architecture/system/parts/flood-node.md
@@ -1,0 +1,73 @@
+# flood-node
+
+## One-line summary
+
+Low-point runoff depth and rise-rate sensor; introduces outdoor deployment class and dedicated `flood.low_point.snapshot` observation family. Geography-gated module — included only for parcels where runoff or pooling is operationally meaningful. Runtime normalization implemented; hardware build spec still open.
+
+## Deployment posture
+
+- **Deployment class:** `outdoor` — per [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated table and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node".
+- **Power tier:** `battery + solar` with documented runtime floor, or `hardened mains` — per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) outdoor-class row.
+- **IP tier:** `IP65` — flood-node installations see standing water; upgraded from IP54 passive default.
+- **Transport tier:** `serial` floor → `LoRa` permitted (low-point mounts often beyond reliable Wi-Fi).
+- **Protective fixtures:**
+  - Rigid mount at a documented low-point.
+  - Zero-reference tied to a physical staff gauge (depth readings are only interpretable against documented geometry).
+- **Sensor variants:**
+  - Water depth: ultrasonic rangefinder, outdoor-rated (e.g., MaxBotix MB7389 or equivalent) — variant TBD per [`../sensor-placement-and-representativeness-guide.md`](../sensor-placement-and-representativeness-guide.md) Sensor variant selection principles.
+  - Rise rate: derived from depth time-series; not a separate sensor.
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` (planned) | not yet drafted | `oesis-builds/specs/flood-node/v0-1.md` — **does not exist** | Skeleton proposal at [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) Skeleton 2. |
+
+Build guide exists at [oesis-hardware/flood-node/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/flood-node) with provisional calibration only; independent reproduction not confirmed.
+
+## Calibration posture
+
+Governed by [`../calibration-program.md`](../calibration-program.md) (physical-sensor program).
+
+- **Deployment-maturity target:** `v1.0` (first fielded kit).
+- **Reference instruments:** flood-node reference = staff gauge + manual depth measurement; not yet populated under `oesis-builds/procedures/flood-node/references/`. Tracked as **G13**.
+- **Burn-in:** not required — ultrasonic sensors do not require conditioning.
+- **Protective fixture verification:** rigid mount + zero-reference + staff gauge acceptance tests to be authored. Without documented geometry, depth numbers are decoration (inadmissible per §C).
+- **Admissibility status:** no readings admissible today (no build spec, no populated reference, no documented geometry acceptance).
+- **§F build-spec metadata block:** planned — skeleton in the proposal cited above.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| `v0.1` / `v0.2` | **not in scope** | v0.1 is indoor-only; v0.2 is indoor + sheltered. |
+| `v0.3` | **first flood-capable slice** (first outdoor-class node enters) | Dedicated `flood.low_point.snapshot` observation family. Milestone 3 in [`../../current/milestone-roadmap.md`](../../current/milestone-roadmap.md). |
+| `v0.4` | low-point node within multi-node registry | Registry + evidence composition. |
+| `v0.5` | unchanged from v0.4 | Governance-gated shared-layer eligibility. |
+| `v1.0` (pre-1.0 ladder) | fleet-wide deployment-maturity `v1.0` | §F / §G compliance attested. |
+| `v1.5` | unchanged | Flood loop (hazard → house-state → action → outcome) partially authored in [`../../v1.5/house-state-and-verification-model.md`](../../v1.5/house-state-and-verification-model.md) "Second closed loop: flood protection". |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node" |
+| Hardware design | [oesis-hardware/flood-node/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/flood-node) |
+| Build spec | **missing** — skeleton in [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) |
+| Runtime normalizer | `oesis.ingest.v0_3.normalize_flood_packet` |
+| Packet schema | `oesis.flood-node.v1` → `flood.low_point.snapshot` — [oesis-contracts/v0.3/](https://github.com/lumenaut-llc/oesis-contracts/tree/main/v0.3) |
+| Gap register entries | **G10** (PRD hazard claims vs bench-air-only sensing includes flood), **G13** (reference instruments), **G17** (admissibility facts in schema) |
+
+## Known gotchas
+
+- **Geometry discipline is non-optional.** One dry point on a parcel does not clear the whole parcel. One wet point may reflect intended drainage concentration, not generalized flooding. See [`../sensor-placement-and-representativeness-guide.md`](../sensor-placement-and-representativeness-guide.md) flood placement guidance.
+- **Provisional calibration only** as of 2026-04-15 (per [`../../current/implementation-posture.md`](../../current/implementation-posture.md)). Promotion to `deployment maturity v1.0` blocked on characterized reference + geometry discipline.
+- **Power runtime floor** — outdoor-class requires 72 h runtime floor under worst-case solar per deployment-maturity-ladder. Undersized solar is a common bring-up mistake.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated section
+- [`../calibration-program.md`](../calibration-program.md) §C protective-fixture rule
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) row v0.3
+- [`../../v1.5/house-state-and-verification-model.md`](../../v1.5/house-state-and-verification-model.md) "Second closed loop: flood protection"
+- [`mast-lite.md`](mast-lite.md) — sheltered-class sibling

--- a/architecture/system/parts/mast-lite.md
+++ b/architecture/system/parts/mast-lite.md
@@ -1,0 +1,75 @@
+# mast-lite
+
+## One-line summary
+
+Sheltered-outdoor reference sensor node; extends the `oesis.bench-air.v1` packet lineage from indoor to sheltered outdoor. The second node in the v0.2 integrated parcel kit. Architecturally in scope today; hardware build spec and field-hardening evidence are the v0.2 promotion blockers.
+
+## Deployment posture
+
+Values cited from canonical sources; do not edit here if upstream changes.
+
+- **Deployment class:** `sheltered` — per [`../node-taxonomy.md`](../node-taxonomy.md) next-promotion table and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node".
+- **Power tier:** `12V-DC` from an outdoor-rated adapter, or USB routed from indoor through a cable gland — per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) Deployment-class standards (sheltered row).
+- **IP tier:** `IP44` minimum — per ladder sheltered row.
+- **Transport tier:** `serial` floor, `Wi-Fi` permitted where coverage is reliable — per ladder sheltered row.
+- **Protective fixtures:** radiation shield required — passive or fan-aspirated. Pre-verification readings inadmissible per [`../calibration-program.md`](../calibration-program.md) §C item 7.
+- **Sensor variants:**
+  - Temperature + humidity: SHT45 with **sintered-filter outdoor-rated variant** per [`../sensor-placement-and-representativeness-guide.md`](../sensor-placement-and-representativeness-guide.md) Sensor variant selection principles — sheltered envelope requires sintered cap for condensation tolerance.
+  - Gas resistance: BME680 — same as bench-air; humidity sensitivity in sheltered environment is a known interpretation caveat.
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` (planned) | **not yet drafted** | `oesis-builds/specs/mast-lite/v0-1.md` — **does not exist** | Tracked as **G12**. Skeleton proposal at [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) Skeleton 1. |
+
+## Calibration posture
+
+Governed by [`../calibration-program.md`](../calibration-program.md) (physical-sensor program).
+
+- **Deployment-maturity target:** `v1.0` — required for v0.2 promotion per [`../../current/pre-1.0-version-progression.md`](../../current/pre-1.0-version-progression.md) item 5.
+- **Reference instruments:** not yet populated — sheltered-class temperature / humidity reference required per §A minimum coverage table. Tracked as **G13**.
+- **Burn-in:** 48 h for BME680 per §B; applies here same as to bench-air.
+- **Protective fixture verification:** radiation shield thermal-loading acceptance test required — not yet authored. Pre-shield readings inadmissible per §C item 7.
+- **Admissibility status:** no readings admissible today (no build spec, no reference instruments, no shield verification).
+- **§F build-spec metadata block:** planned — skeleton provided in the proposal cited above.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| `v0.1` | **not in scope** | v0.1 is bench-air-only indoor slice. |
+| `v0.2` | **sheltered-outdoor half of the two-node kit** (first promotion target) | Paired with bench-air. Milestone 2 in [`../../current/milestone-roadmap.md`](../../current/milestone-roadmap.md). Decision 2026-04-19: write the build spec (option A) rather than scope heat to bridge-path. |
+| `v0.3` | unchanged from v0.2 | Flood-node lands alongside; mast-lite unchanged. |
+| `v0.4` | sheltered node within multi-node registry | Registry lifecycle. |
+| `v0.5` | unchanged from v0.4 | Governance-gated shared-layer contribution. |
+| `v1.0` (pre-1.0 ladder) | fleet-wide deployment-maturity `v1.0` | Full calibration-program §G v1.0 posture attested. |
+| `v1.5` (capability-stage bridge) | **may graduate to `weather-pm-mast`** | Richer outdoor evidence via weather-pm-mast becomes second-wave outdoor lane; mast-lite may step aside per [`../phase-roadmap.md`](../phase-roadmap.md) node-family maturity map. |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) next-promotion; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) Tier 2 + "Deployment posture per node" |
+| Hardware design | [oesis-hardware/mast-lite/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/mast-lite) |
+| Build spec | **missing** — tracked as G12; skeleton in [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) |
+| Build procedures | not yet authored |
+| Runtime normalizer | Shared with bench-air via `oesis.bench-air.v1` lineage; `location_mode: "sheltered"` distinguishes mast-lite packets |
+| Packet schema | Inherits `oesis.bench-air.v1` from [oesis-contracts/v0.1/](https://github.com/lumenaut-llc/oesis-contracts/tree/main/v0.1) |
+| Gap register entries | **G12** (build spec missing — primary blocker), **G13** (reference instruments), **G14** (burn-in gate applies), **G17** (admissibility facts in schema) |
+
+## Known gotchas
+
+- **Build spec does not exist.** This is the central issue. Everything else derives from it. Milestone 2 promotion is blocked until the spec, calibration procedure, and radiation-shield design exist in `oesis-builds/`.
+- **Radiation shield non-optional.** Bare SHT45 outdoor readings are corrupted by solar loading (often 2–4 °C bias). Pre-shield readings are inadmissible per calibration-program §C item 7 — not advisory.
+- **Transport / power coordination.** USB from indoor through cable gland is permitted for sheltered class but requires weatherproof cable path, drip loop, and polyfuse per [oesis-hardware/parcel-kit/power-source-guide.md](https://github.com/lumenaut-llc/oesis-hardware/blob/main/parcel-kit/power-source-guide.md).
+- **Indoor vs sheltered vs outdoor confusion.** "Sheltered" ≠ "outdoor". A covered porch / breezeway / eave-protected wall is sheltered. An open mast is outdoor. Mast-lite targets sheltered. Outdoor-exposed siting requires weather-pm-mast or similar.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) next-promotion table
+- [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) sheltered-class row
+- [`../calibration-program.md`](../calibration-program.md) §C protective-fixture rule
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) row v0.2
+- [`bench-air-node.md`](bench-air-node.md) — indoor sibling
+- [`weather-pm-mast.md`](weather-pm-mast.md) — outdoor successor

--- a/architecture/system/parts/thermal-pod.md
+++ b/architecture/system/parts/thermal-pod.md
@@ -1,0 +1,68 @@
+# thermal-pod
+
+## One-line summary
+
+Research-gated scene-level thermal sensor (fixed field-of-view IR array). Kept outside the default pilot until contract, usefulness, and privacy posture are clearer. Deliberately held at a deployment-maturity tier below `v1.0` — the point is to avoid inheriting a deployability claim from the rest of the kit while the privacy and scene-framing questions are unresolved.
+
+## Deployment posture
+
+- **Deployment class:** `outdoor` (research) — fixed-scene semi-outdoor placement, per [`../node-taxonomy.md`](../node-taxonomy.md) research-gated table and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node".
+- **Power tier:** `mains` — Pi-based platform; power budget for ongoing thermal readout + durable storage.
+- **IP tier:** `IP54` baseline; installation-specific.
+- **Transport tier:** `Wi-Fi` — research lane; no LoRa/cellular fallback in scope.
+- **Protective fixtures:**
+  - Hooded enclosure with documented field-of-view (privacy-reviewed).
+- **Sensor variants:**
+  - Scene thermal: MLX90640 or equivalent 32×24 thermal array.
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` (planned) | not yet drafted | `oesis-builds/specs/thermal-pod/v0-1.md` — **does not exist** | Skeleton proposal at [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) Skeleton 4. |
+
+Hardware research at [oesis-hardware/thermal-pod/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/thermal-pod).
+
+## Calibration posture
+
+Governed by [`../calibration-program.md`](../calibration-program.md) (physical-sensor program).
+
+- **Deployment-maturity target:** **intentionally < `v1.0`** — stays at `v0.1` (bench prototype) until scene-contract, usefulness, and retention posture clear the privacy review. This is not a calibration deficiency; it is a research-lane posture.
+- **`research_gated: true`** flag in the planned §F block — signals admissibility tooling to reject thermal-pod readings from production coefficient-fit datasets per [`../calibration-program.md`](../calibration-program.md) §C.
+- **Reference instruments:** thermal-scene reference = co-located hand-held IR thermometer plus documented surface emissivity. Not yet populated.
+- **Burn-in:** 24 h — thermal arrays require warmup for stable offset.
+- **Protective fixture verification:** field-of-view privacy review is the gating fixture acceptance, not a physical loading test. A node without privacy-reviewed FOV is inadmissible.
+- **Admissibility status:** not admissible to production datasets by design while research-gated.
+- **§F build-spec metadata block:** planned — skeleton in the proposal.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| All pre-1.0 slices and `v1.0` | **not in scope** | Kept outside the critical path for the first parcel kit per [`../../current/milestone-roadmap.md`](../../current/milestone-roadmap.md) "Separate research lane". |
+| `v1.5` (capability-stage bridge) | not in scope | v1.5 bridge uses indoor-response-node + circuit-monitor, not thermal. |
+| Future (post-v1.5, privacy review pending) | promotable to production lane **only if** contract + usefulness + retention posture clear | Will then follow standard calibration-program §G progression. |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) research- or privacy-gated; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) research lane |
+| Hardware research | [oesis-hardware/thermal-pod/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/thermal-pod) |
+| Build spec | **missing** — skeleton in [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) |
+| Runtime normalizer | not yet implemented |
+| Packet schema | `oesis.thermal-pod.v1` → `thermal.scene.snapshot` — planned; not yet in contracts |
+| Gap register entries | none today (research lane is not blocking any promotion) |
+
+## Known gotchas
+
+- **Privacy, not calibration, is the load-bearing blocker.** A calibrated thermal-pod without a reviewed field-of-view is still inadmissible. The order of work is privacy review first, then calibration.
+- **Emissivity matters.** Scene thermal readings depend on surface emissivity assumptions. Calibration without documented surface properties is not traceable.
+- **Not a hazard sensor.** Thermal-pod produces scene context. It does not make hazard claims about occupants or spaces; see [`../vision-and-use-cases.md`](../vision-and-use-cases.md) for research-lane framing.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) research-gated section
+- [`../../current/milestone-roadmap.md`](../../current/milestone-roadmap.md) "Separate research lane"
+- [`../vision-and-use-cases.md`](../vision-and-use-cases.md) — use-case surface
+- [`circuit-monitor.md`](circuit-monitor.md) — sibling specialized lane (v1.5 bridge)

--- a/architecture/system/parts/weather-pm-mast.md
+++ b/architecture/system/parts/weather-pm-mast.md
@@ -1,0 +1,77 @@
+# weather-pm-mast
+
+## One-line summary
+
+Second-wave outdoor sensor node: PM2.5 plus weather (temperature, humidity, pressure, wind). First node in the stack to measure particulate matter. Targets a richer outdoor evidence path once sheltered mast-lite posture is stable. Runtime normalization implemented; hardware build spec not yet authored.
+
+## Deployment posture
+
+- **Deployment class:** `outdoor` — per [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated table and [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) "Deployment posture per node".
+- **Power tier:** `mains` with outdoor-rated PSU routed through conduit — per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) outdoor row; higher-draw sensors (PM airflow module, active heating in some variants) bias toward mains vs battery+solar.
+- **IP tier:** `IP65` for exposed mast installations.
+- **Transport tier:** `Wi-Fi` primary; LoRa or cellular permitted for parcels beyond Wi-Fi reach.
+- **Protective fixtures:**
+  - Radiation shield for SHT45 temperature/humidity.
+  - PM airflow module — flow path for particulate sensing.
+- **Sensor variants:**
+  - PM2.5: laser-scattering sensor (e.g., Sensirion SPS30 or equivalent) — variant TBD.
+  - Temperature + humidity: SHT45 with sintered-filter outdoor-rated variant.
+  - Pressure: BME280 or equivalent.
+  - Wind: cup anemometer or ultrasonic.
+
+## Version evolution
+
+| Build version | Status | Spec path | Notes |
+|---|---|---|---|
+| `v0-1` (planned) | not yet drafted | `oesis-builds/specs/weather-pm-mast/v0-1.md` — **does not exist** | Skeleton proposal at [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) Skeleton 3. |
+
+Hardware documented at [oesis-hardware/weather-pm-mast/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/weather-pm-mast); not independently built.
+
+## Calibration posture
+
+Governed by [`../calibration-program.md`](../calibration-program.md) (physical-sensor program).
+
+- **Deployment-maturity target:** `v1.5` (trust hardening) — higher maturity than v1.0 per [`../deployment-maturity-ladder.md`](../deployment-maturity-ladder.md) node-family maturity map, because the PM mast raises the bar for power design, airflow, maintenance, local buffering, and serviceability.
+- **Reference instruments:**
+  - PM2.5 reference: collocated EPA AQS reference monitor or equivalent — ambitious; tracked as **G13**.
+  - Temperature / humidity: outdoor-rated psychrometer — tracked as G13.
+  - Pressure: barometer — tracked as G13.
+- **Burn-in:** 48 h platform default for BME-family + PM sensor conditioning + airflow stabilization.
+- **Protective fixture verification:** airflow acceptance test + radiation-shield thermal-loading test — both to be authored.
+- **Admissibility status:** no readings admissible today (no build spec, no populated references, no fixture verifications).
+- **§F build-spec metadata block:** planned — skeleton in proposal.
+
+## Role in each program-phase
+
+| Phase | Role | Notes |
+|---|---|---|
+| `v0.1` → `v0.3` | **not in scope** | No outdoor PM evidence required at these phases. |
+| `v0.4` → `v0.5` | available as optional geography-gated module | Not default. |
+| `v1.0` (pre-1.0 ladder) | **second-wave outdoor lane** | May graduate from mast-lite once simpler sheltered outdoor is stable per [`../phase-roadmap.md`](../phase-roadmap.md) node-family maturity map. Maturity target `v1.5`. |
+| `v1.5` (capability-stage bridge) | unchanged role; feeds outdoor PM signal into smoke closed-loop | Smoke loop uses outdoor PM (weather-pm-mast) + indoor PM (indoor-response-node) + HVAC state (equipment-state-adapter) to verify filtration response. |
+
+## Cross-repo link map
+
+| Concern | Location |
+|---|---|
+| Architecture posture row | [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated; [`../integrated-parcel-system-spec.md`](../integrated-parcel-system-spec.md) Tier 3 + "Deployment posture per node" |
+| Hardware design | [oesis-hardware/weather-pm-mast/](https://github.com/lumenaut-llc/oesis-hardware/tree/main/weather-pm-mast) |
+| Build spec | **missing** — skeleton in [`../../../meta/proposals/oesis-builds-node-skeletons.md`](../../../meta/proposals/oesis-builds-node-skeletons.md) |
+| Runtime normalizer | `oesis.ingest.v1_0.normalize_weather_pm_packet` |
+| Packet schema | `oesis.weather-pm-mast.v1` → `air.pm.snapshot` — [oesis-contracts/v1.0/](https://github.com/lumenaut-llc/oesis-contracts/tree/main/v1.0) |
+| Gap register entries | **G13** (reference instruments — PM reference is the hardest to source), **G17** (admissibility facts in schema) |
+
+## Known gotchas
+
+- **PM reference is operationally hard.** EPA AQS-grade collocation is expensive and often not available near pilot parcels. Practical references may use AirNow collocation or PurpleAir cross-check with documented accuracy statements.
+- **Airflow module not a passive shield.** PM readings depend on stable airflow path through the sensor inlet. If the module is plugged, iced, or birdsnested, readings go wrong in ways that don't match temperature/humidity failure modes.
+- **Power draw makes battery+solar marginal.** Active-flow PM sensors consume more than passive T/RH/P setups; mains preferred.
+- **Relative humidity PM correction.** Outdoor PM2.5 readings distort under high RH; Barkjohn formula or equivalent correction is applied in `oesis.inference.divergence_rules_v0.json` — PM sensor choice must support it.
+
+## Related
+
+- [`../node-taxonomy.md`](../node-taxonomy.md) geography-gated section
+- [`../calibration-program.md`](../calibration-program.md) §A minimum coverage table (PM2.5 row)
+- [`../architectural-choices-by-stage.md`](../architectural-choices-by-stage.md) row v1.0 / v1.5
+- [`mast-lite.md`](mast-lite.md) — sheltered predecessor
+- [`flood-node.md`](flood-node.md) — outdoor-class sibling

--- a/architecture/system/phase-roadmap.md
+++ b/architecture/system/phase-roadmap.md
@@ -64,6 +64,15 @@ This means a node family can be architecturally in scope for `current v1` while 
 
 Establish a credible parcel-first sensing and inference product that is useful with one home, honest under sparse evidence, and compatible with partial adoption.
 
+### Deployment posture
+
+Hardware for Stage A lives at **deployment-maturity `v0.1`** (bench) progressing to **`v1.0`** (first fielded kit) per [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md). Class / power / IP / transport defaults by lane-family:
+
+- **`v0.1` reference slice:** indoor class, USB power, IP20, serial transport floor (per G3).
+- **`v0.2` widening:** indoor + sheltered classes; USB or 12V-DC for sheltered; IP44 for sheltered; serial or Wi-Fi; mast-lite radiation shield required.
+- **`v0.3` / `v0.4` / `v0.5`:** adds outdoor class (flood-node, eventually weather-pm-mast); battery+solar or hardened mains; IP65; serial→LoRa/Wi-Fi.
+- **Calibration rigor** scales with deployment-maturity tier per [`calibration-program.md`](calibration-program.md) §G.
+
 ### Outcomes
 
 - canonical parcel-state model and evidence-mode language
@@ -82,6 +91,7 @@ Establish a credible parcel-first sensing and inference product that is useful w
 - keep `unknown` and low-confidence outcomes honest
 - define recommendation-language boundaries before shipping action prompts
 - preserve the current parcel-state contract through this stage
+- document the calibration program and adapter-trust program as platform-level standards that every node and adapter family inherits (`calibration-program.md`, `adapter-trust-program.md`)
 
 ### Exit criteria
 
@@ -97,6 +107,16 @@ Establish a credible parcel-first sensing and inference product that is useful w
 
 Add the minimum new data needed so the platform can evolve from parcel sensing into parcel adaptation without pretending that the adaptation engine already exists.
 
+### Deployment posture
+
+Adds v1.5 bridge hardware and adapter surfaces. Class / power per family:
+
+- `indoor-response-node`: indoor / USB / IP20 / Wi-Fi — physical sensor, governed by `calibration-program`.
+- `power-outage-node`: indoor / **battery-backed** (intrinsic to use case) / IP20 / Wi-Fi or LoRa.
+- `circuit-monitor` (Tier 3 direct measurement): mains-adjacent / low-power from measured circuit / electrical-enclosure IP20 / Wi-Fi.
+- `equipment-state-adapter` (Tier 2 cloud API) and passive thermal-slope inference (Tier 1): adapter surfaces with no physical posture of their own — governed by [`adapter-trust-program.md`](adapter-trust-program.md) rather than calibration-program.
+- **Calibration rigor** target: `deployment maturity v1.5` (trust hardening) per calibration-program §G; versioned calibration state and drift-aware offsets expected.
+
 ### Core rule
 
 Collect the minimum data needed to model the relationship between outdoor hazards, house operating state, available interventions, and resulting outcomes.
@@ -109,6 +129,7 @@ Collect the minimum data needed to model the relationship between outdoor hazard
 - building and site metadata such as orientation, roof type or color, shading, tree canopy, impervious area, low points, drainage paths, vent locations, filter path, filter size, and higher-MERV support
 - intervention and response records such as `action-log`, `outcome-log`, and before/after response windows
 - **read-side** equipment-state and coarse capability hints (what exists / what is observed), without requiring a full **controls-compatibility inventory** — that inventory (interface classes, integration tiers, policy versioning) is primarily **Stage D / `v2.5`**
+- adapter-trust posture for `equipment-state-adapter` and passive thermal-slope inference: each adapter declares its source authority, pinned contract version, and cross-check posture per [`adapter-trust-program.md`](adapter-trust-program.md)
 
 ### Design rule
 
@@ -146,6 +167,10 @@ with evidence-quality limits carried into the outcome interpretation and without
 
 Turn parcel sensing plus `v1.5` support data into serious engineering guidance without implying autonomous control.
 
+### Deployment posture
+
+No new physical-sensor classes introduced; Stage C is software-layered on Stage B hardware. Adapter-trust program §G compliance expected at `deployment maturity v1.5` for every adapter consumed by guidance logic. Advisory outputs only; no control surfaces yet.
+
 ### Core capabilities
 
 - condition model
@@ -166,6 +191,10 @@ Turn parcel sensing plus `v1.5` support data into serious engineering guidance w
 ### Goal
 
 Prepare the system to interact with real homes through bounded, low-risk control surfaces and compatibility mapping.
+
+### Deployment posture
+
+Introduces control-side adapter surfaces; no new physical-sensor classes required beyond Stage B. Control-path adapters (Matter / Home Assistant / BACnet / cloud-only) each declare source-authority and bounded-control semantics via adapter-trust program §F. Promotion bar: every consumed adapter at `deployment maturity v2.0` (decision-policy support) per calibration-program §G / adapter-trust §G; cross-adapter consistency audits required.
 
 ### Core capabilities
 
@@ -196,6 +225,10 @@ Prepare the system to interact with real homes through bounded, low-risk control
 
 Move from current-state guidance into a real parcel adaptation engine.
 
+### Deployment posture
+
+Hardware requirements inherited from Stage D; no new physical-sensor classes. `deployment maturity v2.0` required for the whole in-use fleet to support adaptation memory — retired/degraded devices must be visibly tracked so learned priors don't encode defunct devices as baseline.
+
 ### Core capabilities
 
 - time-to-threshold outputs
@@ -209,6 +242,10 @@ Move from current-state guidance into a real parcel adaptation engine.
 ### Goal
 
 Extend beyond the house to route, egress, and shared neighborhood infrastructure resilience while preserving private-by-default household data handling.
+
+### Deployment posture
+
+Stage F introduces route / block / neighborhood surfaces built from aggregated parcel-private outputs. No new per-parcel hardware classes required beyond Stages A–E. Shared-layer eligibility is gated on per-contributor calibration-program admissibility per gap register G22.
 
 ### Core capabilities
 
@@ -227,7 +264,7 @@ These workstreams should advance continuously across phases:
 - privacy and consent tooling
 - sensor-health scoring
 - observability and provenance
-- calibration and deployment guidance
+- calibration program (reference instruments, burn-in, admissibility, drift) and adapter-trust program (source authority, API contract version, schema-drift detection)
 - shared terminology and claims discipline
 - local-first and degraded-connectivity behavior
 - partnership and governance models

--- a/architecture/system/sensor-placement-and-representativeness-guide.md
+++ b/architecture/system/sensor-placement-and-representativeness-guide.md
@@ -85,6 +85,18 @@ Weaknesses:
 - can still be distorted by sun, walls, pavement, or direct runoff peculiarities
 - requires better calibration and siting discipline
 
+## Deployment-class mapping
+
+Placement category determines the deployment class a node must be built to, which in turn determines power / IP / transport tier per [`deployment-maturity-ladder.md`](deployment-maturity-ladder.md) "Deployment-class standards". This table is the canonical link between placement language here and deployment-class language there:
+
+| Placement category | Required deployment class | Power tier | IP tier | Transport floor |
+| --- | --- | --- | --- | --- |
+| Indoor | indoor | USB from protected supply | none / IP20 | serial (v0.1 floor); Wi-Fi / wired LAN permitted |
+| Sheltered | sheltered | 12 V-DC from outdoor-rated adapter, or USB if within an enclosed space | IP44 | serial; Wi-Fi where coverage is reliable; LoRa permitted |
+| Outdoor | outdoor | Battery + solar with documented runtime floor, or mains with outdoor-rated PSU routed through conduit | IP54 (passive) / IP65+ (exposed mast) | serial during bring-up only; Wi-Fi where coverage is verified; LoRa or cellular for parcels beyond Wi-Fi reach |
+
+A node whose declared deployment class does not match its physical installation class produces readings that are inadmissible to the calibration dataset per [`calibration-program.md`](calibration-program.md) §C item 3. This is the enforcement link between placement discipline and admissibility.
+
 ## Representativeness classes
 
 The product should classify placement representativeness explicitly.
@@ -236,6 +248,45 @@ During pilots, the team should document:
 - treating all connected sensors as equally trustworthy
 - silently upgrading indoor readings into parcel truth
 - letting poor siting create false neighborhood gradients
+
+## Sensor variant selection principles
+
+When a sensor family ships in multiple variants (for example filtered vs unfiltered SHT45, or BME680 vs BME688), the choice of variant is not cosmetic. It must follow from the placement category the node will occupy and the measurand's tolerance requirements. The rules below are platform-level; specific variant part numbers live in each node's build spec.
+
+### Variant selection is driven by placement, not the reverse
+
+Placement decides the environmental envelope the sensor must tolerate. The sensor variant must be rated for that envelope before the node is spec'd. Picking the variant first and then discovering it cannot survive the intended placement produces field failures that cannot be corrected in software.
+
+### Required minimum tolerances by placement category
+
+| Placement category | Operating-temperature range | Humidity / condensation | Contamination |
+|---|---|---|---|
+| Indoor | Typical HVAC envelope, 10–35 °C | Non-condensing; standard variants acceptable | Dust from HVAC circulation; PTFE or membrane filter recommended near returns |
+| Sheltered | −10 to 50 °C depending on climate zone | Occasional condensation; PTFE or equivalent membrane filter required | Pollen, spider ingress, insect nest risk; enclosure membrane venting required |
+| Outdoor | Full local climate envelope, documented per parcel's climate zone | Condensation routine; sintered cap or equivalent protective fixture required | UV, salt (coastal), pollen, ember exposure (WUI), precipitation |
+
+A variant must be rated for the full envelope at the placement category it serves. Nodes deployed outside a sensor's rated envelope produce readings whose accuracy is unbounded; such readings are inadmissible under [`calibration-program.md`](calibration-program.md) §C.
+
+### Accuracy-tier requirements driven by formula sensitivity
+
+The hazard formula's coefficient sensitivity determines the accuracy floor a sensor variant must satisfy for its measurand to be admissible.
+
+Current requirements inferred from [`../../software/inference-engine/hazard-formula-v1.md`](../../software/inference-engine/hazard-formula-v1.md) and [`hazard-formula-v1-phase1.md`](../../software/inference-engine/hazard-formula-v1-phase1.md):
+
+| Measurand | Accuracy floor for admissibility | Rationale |
+|---|---|---|
+| Temperature (any placement) | ±0.3 °C or better across the operating range | The heat sensor term z-scores against climate-normal σ, which is typically 1–3 °C; a ±0.3 °C sensor is well inside that noise floor. Larger error would dominate the z-score. |
+| Relative humidity | ±3 % RH or better | Required for optional heat index / WBGT correction and for condensation-event detection |
+| Gas resistance (VOC trend) | No absolute accuracy floor; per-device rolling baseline is what the formula consumes | Repeatability and noise are what matter, not absolute ohms. Stability is gated by the burn-in policy in `calibration-program.md` §B |
+| PM2.5 | Accuracy floor TBD per sensor family when a PM-capable node lands | Not required for current hardware lanes |
+
+### Cost and availability
+
+Cost and availability are documented in the node build spec, not here. The platform policy requires that a chosen variant be: (a) sourceable at pilot scale, (b) replacement-compatible across revisions of the node family, and (c) retained as a line item in the `oesis-builds` BOM until explicitly retired. A variant that is temporarily unavailable is not a reason to drop to a lower-accuracy variant; it is a reason to pause deployment of that node family until the variant or an approved equivalent is back in stock.
+
+### Substitutions and equivalents
+
+Any substitution of a sensor variant (e.g., BME680 → BME688, or SHT45 → SHT45-AD1B to -AD2B) is a build decision that must be recorded in an `oesis-builds/decisions/<node>/` entry, and the substitution is valid only after the replacement's accuracy and envelope are verified against the standards above. A substitution cannot reduce the tolerance envelope or accuracy floor without a new calibration session and an update to the node's deployment-maturity posture.
 
 ## Open questions
 

--- a/architecture/system/technical-philosophy-and-architecture.md
+++ b/architecture/system/technical-philosophy-and-architecture.md
@@ -118,6 +118,37 @@ operating constraints, and the docs that define boundaries between them.
 If the docs and the system behavior diverge, the architecture has failed even if
 the code still runs.
 
+### 9. Admissibility is part of evidence boundaries, not an inference side-effect
+
+The system should treat calibration posture and admissibility decisions as
+first-class evidence-layer facts, not as ingest hygiene or inference
+implementation details.
+
+Two architectural commitments follow:
+
+- **Schema carries the facts, runtime computes the decision.** The canonical
+  observation schema carries the facts admissibility depends on (burn-in state,
+  calibration session reference, deployment class, protective-fixture
+  verification, adapter source authority); the admissibility decision itself —
+  the boolean plus reason codes — lives on the normalized observation in
+  runtime. This keeps schema stable as admissibility policy evolves, and
+  preserves the reasoning trail for audit.
+
+- **Physical-sensor trust and adapter-derived trust are parallel programs.**
+  Physical sensors are governed by the calibration program (reference
+  instruments, burn-in, drift); adapter-derived evidence (Tier 1 passive
+  inference, Tier 2 cloud APIs) is governed by the adapter-trust program
+  (source authority, API contract version, schema-drift detection). Both
+  produce the same admissibility output through different evidence paths; the
+  programs must stay independent to avoid conflating physical and API-contract
+  failure modes.
+
+Canonical docs:
+[`integrated-parcel-system-spec.md`](integrated-parcel-system-spec.md)
+"Calibration and admissibility layer";
+[`calibration-program.md`](calibration-program.md);
+[`adapter-trust-program.md`](adapter-trust-program.md).
+
 ## Architectural shape
 
 ### Layer 1. Evidence collection

--- a/architecture/system/version-and-promotion-matrix.md
+++ b/architecture/system/version-and-promotion-matrix.md
@@ -17,7 +17,7 @@ Use this document when writing roadmaps, kit language, or marketing so **taxonom
 | --- | --- | --- |
 | **Accepted runnable slice** | What end-to-end story is **promoted** as the current honest baseline? | `v0.1` today; `v0.2` when bench-air + mast-lite + contracts/runtime meet the promotion bar |
 | **Capability stage** | What **class of product behavior** is in scope for architecture and contracts? | `current v1` sensing/inference; `v1.5` intervention bridge objects |
-| **Deployment maturity** | Is this **node family** bench-grade or field-hardened? | Per family in `deployment-maturity-ladder.md` |
+| **Deployment maturity** | Is this **node family** bench-grade or field-hardened? | Per family in `deployment-maturity-ladder.md`; calibration posture required at each tier is in `calibration-program.md` |
 | **Implementation status** | For each surface, what is actually shipped vs drafted? | Runtime observation table in `integrated-parcel-system-spec.md` |
 
 **Folder note:** `architecture/current/` is the frozen **architecture lane** aligned with program-phase `v0.1`. That is **not** the same label as capability stage `current v1` (see `architecture-gaps-by-stage.md`).
@@ -69,7 +69,11 @@ Revocation, sharing/consent execution, and some governance paths may remain **do
 - `../current/pre-1.0-version-progression.md`
 - `node-taxonomy.md`
 - `architecture-gaps-by-stage.md`
+- `architectural-choices-by-stage.md`
 - `deployment-maturity-ladder.md`
+- `calibration-program.md`
+- `adapter-trust-program.md`
+- `sensor-placement-and-representativeness-guide.md`
 - `integrated-parcel-system-spec.md`
 - `phase-roadmap.md`
 - [`v0.1/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/README.md)

--- a/architecture/system/vision-and-use-cases.md
+++ b/architecture/system/vision-and-use-cases.md
@@ -220,6 +220,8 @@ The product should help people decide what to do next, not only show measurement
 
 The project should only expand into stronger control or adaptation claims after it can measure house state, log interventions, and verify whether those actions improved outcomes.
 
+Admissibility is the concrete mechanism by which this discipline runs. A reading enters inference only if it passes the calibration program's admissibility check (or the adapter-trust program's equivalent for Tier 1 / Tier 2 data). Inadmissible readings remain in audit logs but do not shape parcel claims. See [`calibration-program.md`](calibration-program.md) §C and [`adapter-trust-program.md`](adapter-trust-program.md) §C.
+
 ### Honest uncertainty before overclaiming
 
 The system must clearly separate:

--- a/architecture/v1.5/README.md
+++ b/architecture/v1.5/README.md
@@ -38,3 +38,23 @@ outcome reasoning.
 - `../system/phase-roadmap.md`
 - `../system/node-taxonomy.md`
 - `../system/architecture-gaps-by-stage.md`
+
+## Why this lane is thin
+
+This directory intentionally holds only **narrow bridge-stage specifics** that don't belong in the cross-version `../system/` lane. Most v1.5 architecture content — roadmap, node taxonomy, gaps, choices — lives in `system/` because it is cross-version. A reader navigating to `v1.5/` looking for "the v1.5 architecture" will find one narrow doc here; the rest is in `system/` and is **cited**, not duplicated, by design.
+
+### Where v1.5 content actually lives (authoritative map)
+
+| v1.5 concern | Canonical location |
+|---|---|
+| Bridge-stage surface definitions (indoor-response-node, power-outage-node, equipment-state-adapter, action-log, outcome-log, building metadata) | [`house-state-and-verification-model.md`](house-state-and-verification-model.md) (this lane) |
+| Stage-B deployment posture (power tier, IP, transport, calibration rigor per v1.5 surface) | [`../system/phase-roadmap.md`](../system/phase-roadmap.md) Stage B |
+| How v1.5 bridge surfaces fit the node taxonomy (Tier 1 passive / Tier 2 cloud / Tier 3 direct acquisition model) | [`../system/node-taxonomy.md`](../system/node-taxonomy.md) "Capability-stage v1.5 bridge" section |
+| Operational-architecture gaps specific to v1.5 | [`../system/architecture-gaps-by-stage.md`](../system/architecture-gaps-by-stage.md) v1.5 row |
+| Architectural choices (class / power / IP / transport / calibration / adapter tier) at v1.5 | [`../system/architectural-choices-by-stage.md`](../system/architectural-choices-by-stage.md) v1.5 row |
+| Adapter-trust program for Tier 1 / Tier 2 data (load-bearing at v1.5) | [`../system/adapter-trust-program.md`](../system/adapter-trust-program.md) |
+| Part sheets for v1.5 bridge hardware (indoor-response-node, power-outage-node, circuit-monitor) | [`../system/parts/`](../system/parts/) |
+| Per-phase narrative and between-stage deltas | [`../system/architectural-choices-by-stage.md`](../system/architectural-choices-by-stage.md) "Per-phase narrative" and "Between-stage deltas" sections |
+| Program-packet v1.5 phase framing | [`../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md`](../../program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md) v1.5 section |
+
+The thinness of this directory is not a gap. It is the lane model working as intended: cross-version content stays in `system/` to avoid being duplicated across `current/`, `v1.0/`, and `v1.5/` with drift risk.

--- a/architecture/v1.5/house-state-and-verification-model.md
+++ b/architecture/v1.5/house-state-and-verification-model.md
@@ -54,6 +54,8 @@ Why it belongs this early:
 Without indoor response, the system can describe outdoor hazard but cannot tell
 whether the house is actually buffering occupants from that hazard.
 
+Deployment posture: **indoor / USB / IP20 / Wi-Fi** per [`../system/deployment-maturity-ladder.md`](../system/deployment-maturity-ladder.md); physical-sensor node governed by [`../system/calibration-program.md`](../system/calibration-program.md) (reference instruments required per §A; §F metadata block declared in `oesis-builds/specs/indoor-response-node/v0-X.md`).
+
 ### `power-outage-node`
 
 Minimum measurements:
@@ -64,6 +66,8 @@ Minimum measurements:
 Richer battery, generator, and transfer posture can come later, but continuity
 and outage readiness belong in the bridge stage because household function
 during disruption is part of resilience, not an optional add-on.
+
+Deployment posture: **indoor / battery-backed / IP20 / Wi-Fi or LoRa**. Battery-backed power is intrinsic to the use case — a continuity monitor that loses power is useless. Calibration posture: physical-sensor node under calibration-program; status/transition detection characterized against a known reference (e.g., a switched-off utility circuit) per §A.
 
 ### `equipment-state-adapter`
 
@@ -80,6 +84,14 @@ Minimum read-side signals where relevant:
 This is an observation surface, not yet a controls platform.
 The point is to learn which operating surfaces exist at a parcel and what state
 they were in when outcomes changed.
+
+Deployment posture: **adapter (no physical power or enclosure of its own)**. Three acquisition tiers per [`../system/node-taxonomy.md`](../system/node-taxonomy.md):
+
+- **Tier 1 passive inference** (e.g., thermal-slope HVAC detection): zero hardware; governed by [`../system/adapter-trust-program.md`](../system/adapter-trust-program.md) with the inference method itself as the "source authority".
+- **Tier 2 cloud API** (Ecobee, Nest, Sensibo, Honeywell): no physical power; governed by adapter-trust program with OAuth2 / API-key source authority and pinned contract version.
+- **Tier 3 direct measurement** via `circuit-monitor`: **mains-adjacent / low-power from measured circuit / electrical-enclosure IP20 / Wi-Fi**; physical-sensor node under calibration-program.
+
+All three tiers feed the same `equipment-state-observation` schema; runtime selects the highest-fidelity source available per parcel.
 
 ### `action-log`
 

--- a/legal/README.md
+++ b/legal/README.md
@@ -1,4 +1,34 @@
-# Redirect
+# Legal — navigation
 
-Canonical legal baseline lane contract moved to
-[`v0.1/README.md`](v0.1/README.md).
+This directory holds licensing, contribution, defensive publication, and governance-related artifacts across per-slice lanes.
+
+## Redirect
+
+Canonical legal baseline lane contract moved to [`v0.1/README.md`](v0.1/README.md). Follow the redirect for the full lane reading-path.
+
+## Quick reading paths by question
+
+If you landed here from a link, pick the question that matches what you need:
+
+| Question | Start at |
+|---|---|
+| What licenses apply to code, docs, hardware? | [`v0.1/README.md`](v0.1/README.md) "Core governance docs" section + [`licenses/README.md`](licenses/README.md) |
+| How is IP handled? | [`ip.md`](ip.md) + [`defensive-publication/README.md`](defensive-publication/README.md) |
+| What can I publish vs. hold back? | [`public-preview-scope.md`](public-preview-scope.md) + [`holdback-list.md`](holdback-list.md) |
+| How are datasets released? | [`dataset-release-policy.md`](dataset-release-policy.md) |
+| What about pilot participants? | [`pilot-and-research-data-agreement-template.md`](pilot-and-research-data-agreement-template.md) + [`privacy/README.md`](privacy/README.md) |
+| How is privacy enforced? | [`privacy/README.md`](privacy/README.md) |
+| Where does contribution policy live? | [`contribution-policy/README.md`](contribution-policy/README.md) + [`../CONTRIBUTING.md`](../CONTRIBUTING.md) |
+| Which files are historical planning artifacts vs. live policy? | [`v0.1/README.md`](v0.1/README.md) "Archival Path B materials" section |
+| Is there an ADR for a specific decision? | [`../meta/adr/README.md`](../meta/adr/README.md) — index by domain includes privacy, data, and claims decisions |
+
+## Per-slice lanes
+
+- **`v0.1/`** — active policy baseline per [`v0.1/README.md`](v0.1/README.md)
+- **`v0.2/` … `v0.5/`** — per-slice overlays; see [`v0.1/README.md`](v0.1/README.md) "Lane contract" for the inheritance rule (most slices inherit v0.1)
+
+## Related navigation surfaces
+
+- [`../README.md`](../README.md) "Navigating this repo" — cross-directory landing page
+- [`../meta/markdown-canonical-topic-matrix.md`](../meta/markdown-canonical-topic-matrix.md) — authority map for overlapping topics
+- [`../meta/doc-discipline.md`](../meta/doc-discipline.md) — rules for extending vs. creating docs (including redirect self-identification rule 5)

--- a/meta/adr/0007-hazard-formula-v1-sensor-primary-log-odds.md
+++ b/meta/adr/0007-hazard-formula-v1-sensor-primary-log-odds.md
@@ -1,0 +1,70 @@
+# ADR 0007: Hazard Formula v1 — Sensor-Primary Log-Odds Form
+
+- Status: Accepted
+- Date: 2026-04-19
+- Owners: Open Environmental Sensing and Inference System (technical)
+- Related workstreams:
+  - software/inference-engine
+  - oesis-runtime (planned v1_1/ module)
+  - release/v.0.1 (gap-register G11)
+
+## Context
+
+Hazard formula v0 (`config/hazard_thresholds_v0.json` with `parcel_first_hazard.py`) computes smoke and heat probabilities by summing band lookups (`prob += band_value`) then clamping. Three problems:
+
+1. **No provenance.** Every numeric threshold is an expert-elicitation placeholder with no cited source.
+2. **No coherent combination math.** Additive probabilities with post-hoc clamping doesn't correspond to any probabilistic model; it cannot be calibrated (Brier score, ECE) and adding evidence doesn't behave like Bayes.
+3. **Sensor primacy not expressed.** Public and shared-neighborhood signals combine additively into the same probability, weakening the architectural claim that OESIS is sensor-first.
+
+Meanwhile, pilot incident logs are the only ground-truth source available (not EPA/NWS datasets), and hardware for outdoor temperature sensing (mast-lite) is the v0.2 promotion target — so any formula rewrite must accommodate sensor-primary with sensor capability that is itself still maturing.
+
+## Decision
+
+Adopt a **sensor-primary log-odds formulation** for smoke and heat hazards. For hazard $h$ at parcel $p$ at time $t$:
+
+$$\text{logit}(P_h) = \alpha_h + \beta_h \cdot S_h(t) + \sum_{i} \gamma_{h,i} \cdot \pi_{h,i}(p) + \delta_h \cdot H(t)$$
+
+- $S_h(t)$ is the **sensor evidence term** — dominant by construction.
+- $\beta_h$ is the sensor coefficient; required constraint: $|\beta_h| > \sum_i |\gamma_{h,i}|$ (sensor weight exceeds sum of absolute prior coefficients).
+- $\gamma_i$ are parcel priors (construction, defensible space, distance to wildland for smoke; heat retention, HVAC for heat).
+- $H(t)$ is a sensor-health term, negative-only (degraded health reduces sensor weight, never inverts it).
+- **Public and shared sources never appear in the logit.** They calibrate coefficients upstream and feed `divergence_score` channels downstream — reported alongside $P_h$, never folded into it.
+
+Additional commitments:
+- Smoke sensor term uses per-device rolling-baseline deviation of gas resistance (48h window, MAD-based σ), not fixed ohm cutoffs.
+- Heat sensor term uses per-parcel per-date z-scores against NCEI climate normals (both daily max and daily min), not a fixed HeatRisk onset temperature.
+- Every numeric value in the v1 config carries a provenance schema: `value`, `source`, `source_type`, `date`, `note`, plus `n_events` / `ci_95` for internally-fit values.
+- Formula specified in [`../../software/inference-engine/hazard-formula-v1.md`](../../software/inference-engine/hazard-formula-v1.md); Phase-0 prerequisites in [`../../software/inference-engine/hazard-formula-v1-phase1.md`](../../software/inference-engine/hazard-formula-v1-phase1.md).
+
+## Consequences
+
+Positive:
+- Each coefficient is calibratable against pilot labels via logistic or isotonic fit.
+- Brier score and ECE become reportable per hazard.
+- Sensor-primacy is a numerical constraint, not a convention.
+- Divergence between local sensor and public/shared context is preserved as a separate signal rather than muted by addition.
+- Every threshold cites a source; unsourced entries are visible and blocked.
+
+Negative:
+- Requires coefficient fitting against pilot data — gated by hardware calibration prerequisites (G13, G14, G17) and by having enough labeled pilot events per hazard (≥10 positive events per coefficient for internal fits, else coefficient stays literature-prior with citation).
+- Transition runs v1_1 in shadow against v0 until Brier/ECE beat v0 replayed on the same pilot labels — adds schedule overhead.
+- v1 heat primary path requires mast-lite outdoor temperature — blocked by G12.
+
+## Alternatives considered
+
+**Keep v0 bands, add provenance tags to existing values.**
+Rejected: bands can be tagged with sources, but the additive-combination math would still be incoherent. Provenance without formula coherence does not fix the calibration problem.
+
+**Fit a small ML model (gradient-boosted tree or shallow NN) against pilot labels.**
+Rejected at this stage: pilot event counts are too sparse to avoid overfitting, and interpretability is a program-level requirement ("prefer transparent rules over complex models" per [`../../architecture/system/technical-philosophy-and-architecture.md`](../../architecture/system/technical-philosophy-and-architecture.md) principle 5). May revisit at `v1.5+` when data accumulates.
+
+**Add public/shared signals additively to logit.**
+Rejected per user direction: sensor is main source of truth; research and public data are contrast, not evidence. B2 decision reinforces this by separating adapter-derived data into its own trust program (ADR 0010).
+
+## Follow-up work
+
+- Resolve Phase-0 hardware prerequisites per [`../../software/inference-engine/hazard-formula-v1-phase1.md`](../../software/inference-engine/hazard-formula-v1-phase1.md) §0.
+- Implement rolling-baseline replay harness in `oesis-runtime/research/rolling_baseline/`.
+- Preload NCEI climate normals for every pilot parcel at onboarding.
+- Stand up v1_1 shadow module in oesis-runtime when mast-lite hardware + reference instruments are in place.
+- Brier/ECE calibration gate must beat v0 replayed on same pilot labels before v1 is promoted.

--- a/meta/adr/0008-mast-lite-build-spec-as-milestone-2-gate.md
+++ b/meta/adr/0008-mast-lite-build-spec-as-milestone-2-gate.md
@@ -1,0 +1,62 @@
+# ADR 0008: Mast-Lite Build Spec as Milestone 2 Gate (Option A)
+
+- Status: Accepted
+- Date: 2026-04-19
+- Owners: Open Environmental Sensing and Inference System (hardware + technical)
+- Related workstreams:
+  - oesis-hardware/mast-lite
+  - oesis-builds/specs/mast-lite (planned)
+  - architecture/current/milestone-roadmap
+  - release/v.0.1 (gap-register G12)
+
+## Context
+
+Mast-lite is the sheltered-outdoor sensor node that completes the v0.2 two-node parcel kit (bench-air + mast-lite) per [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md). It is architecturally required for program-phase v0.2 promotion.
+
+However:
+- No build spec exists at `oesis-builds/specs/mast-lite/` (gap G12).
+- No calibration procedure exists.
+- No radiation-shield design or thermal-loading acceptance test is documented.
+- Hardware build-guide exists at `oesis-hardware/mast-lite/` but has not been independently reproduced.
+- The v1 hazard formula's primary heat path (per ADR 0007) assumes outdoor temperature from mast-lite.
+
+Two options presented:
+
+- **Option A.** Write the mast-lite build spec, calibration procedure, and radiation-shield design as a Milestone 2 acceptance gate. Primary heat path targets mast-lite outdoor temperature.
+- **Option B.** Scope heat formula to indoor-bridge-only (bench-air indoor SHT45 with 0.4× coefficient discount). Defer mast-lite. Primary outdoor heat path lands at Milestone 4 with weather-pm-mast or mast-lite maturity.
+
+## Decision
+
+**Option A is chosen.** Mast-lite build spec, calibration procedure, and radiation-shield design become Milestone 2 acceptance gates. The v1 hazard formula's primary heat path is mast-lite outdoor temperature, not indoor-bridge-only.
+
+Concretely, Milestone 2 acceptance per [`../../architecture/current/milestone-roadmap.md`](../../architecture/current/milestone-roadmap.md) requires:
+- `oesis-builds/specs/mast-lite/v0-1.md` with BOM, wiring, firmware pin-out, reproducible build
+- `oesis-builds/procedures/mast-lite/calibration.md` with a characterized reference instrument
+- Radiation-shield design inside the build spec with thermal-loading acceptance test
+- Build independently reproduced once before Milestone 2 promotion
+- All node families in the v0.2 kit (bench-air + mast-lite) at `deployment maturity v1.0` calibration posture per calibration-program §G (see ADR 0009)
+
+## Consequences
+
+Positive:
+- Primary heat path is sensor-backed outdoor temperature, not an indoor proxy with 0.4× discount. Preserves sensor-primacy architectural claim (ADR 0007) for both hazards, not just smoke.
+- v0.2 promotion produces a credible two-node parcel kit rather than a one-node plus a degraded bridge.
+- Per-node part sheet [`../../architecture/system/parts/mast-lite.md`](../../architecture/system/parts/mast-lite.md) becomes the aggregator as the work progresses.
+
+Negative:
+- Adds real hardware-spec-writing work to Milestone 2. G12 is now a primary blocker; G13 (reference instruments) and G14 (burn-in gate) bite in parallel.
+- Milestone 2 promotion cannot happen purely via runtime changes; hardware work is on the critical path.
+- If mast-lite hardware owner is under-resourced, v0.2 blocks indefinitely.
+
+## Alternatives considered
+
+**Option B (indoor-bridge-only heat).**
+Rejected because the indoor-bridge path cannot physically represent parcel-wide outdoor heat. Parcel-state outputs at v0.2 would be making claims their sensor can't back. The formal v0.2 promotion bar ("first indoor + sheltered outdoor kit") implies an outdoor source; degrading to indoor-only would make v0.2 structurally narrower than its own definition.
+
+## Follow-up work
+
+- Build-vault agent to apply proposal [`../proposals/oesis-builds-node-skeletons.md`](../proposals/oesis-builds-node-skeletons.md) Skeleton 1 (mast-lite §F block).
+- Author radiation-shield thermal-loading acceptance test under `oesis-builds/specs/mast-lite/`.
+- Populate reference instrument for sheltered-class temperature/humidity under `oesis-builds/procedures/mast-lite/references/` (closes part of G13).
+- Independent build reproduction required before Milestone 2 promotion.
+- Update part sheet as work lands.

--- a/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md
+++ b/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md
@@ -1,0 +1,77 @@
+# ADR 0009: Admissibility — Schema Carries Facts, Runtime Computes Decision
+
+- Status: Accepted
+- Date: 2026-04-19
+- Owners: Open Environmental Sensing and Inference System (technical, cross-repo)
+- Related workstreams:
+  - architecture/system/calibration-program (§C)
+  - architecture/system/adapter-trust-program (§C)
+  - oesis-contracts (observation schema — planned extensions)
+  - oesis-runtime (ingest — admissibility wiring, planned)
+  - release/v.0.1 (gap-register G15, G17)
+
+## Context
+
+The calibration program's admissibility rule (calibration-program §C; parallel adapter-trust-program §C) requires 8 runtime checks per normalized observation. Where should those checks live across the cross-repo boundary?
+
+Three options:
+
+- **A1.** Pure runtime. Admissibility decision computed in ingest; schema never represents it. Different consumers may compute differently; audit trail weakens.
+- **A2.** Schema carries the decision. Canonical observation contains `admissible: bool` + reason codes. Uniform across consumers, but locks one view and churns the schema when policy evolves.
+- **A3.** Hybrid. Schema carries the **facts** (burn-in state, reference-cal session pointer, deployment class, etc.); runtime computes the **decision** on normalized observations.
+
+This affects `oesis-contracts` (canonical observation schema), `oesis-runtime` (ingest and inference), and every consumer that reads normalized observations.
+
+## Decision
+
+**Adopt A3: schema carries facts, runtime computes decision.**
+
+Schema extensions (planned in `oesis-contracts` v1.0 lane; tracked as G17):
+
+Physical-sensor facts per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §C:
+- `burn_in_complete: bool`
+- `node_calibration_session_ref: string`
+- `node_deployment_maturity: enum` (`v0.1` | `v1.0` | `v1.5` | `v2.0`)
+- `node_deployment_class: enum` (`indoor` | `sheltered` | `outdoor`)
+- `protective_fixture_verified_at: timestamp | null`
+- `placement_representativeness_class: enum | null` (A / B / C / D)
+
+Adapter-derived facts per [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §C:
+- `adapter_source_ref: string`
+- `adapter_contract_version: string`
+- `adapter_onboarding_ref: string`
+- `adapter_credential_last_verified_at: timestamp`
+- `adapter_tier: enum` (`tier_1_passive` | `tier_2_adapter` | `tier_3_direct`)
+
+Runtime outputs on normalized observations (never back-propagated to schema):
+- `admissible_to_calibration_dataset: bool`
+- `admissibility_reasons: [string]` (reason codes: `burn_in_incomplete`, `reference_calibration_stale`, `fixture_unverified`, `contract_version_drift`, `credentials_expired`, etc.)
+
+Runtime branches on `adapter_tier`: absent or `tier_3_direct` → calibration-program §C rules; `tier_1_passive` or `tier_2_adapter` → adapter-trust-program §C rules.
+
+## Consequences
+
+Positive:
+- **Schema stays stable** as admissibility policy evolves. Policy lives in code, not in contract.
+- **Every consumer sees the same facts** — no consumer re-probes the node registry or reference-calibration log.
+- **Audit trail preserved** on normalized records. Coefficient-fitting filters on the boolean; audit tooling reads reasons.
+- **Historical records remain interpretable** under old rules and re-evaluable under new rules.
+- Works across the two-programs architecture (calibration + adapter-trust) via the `adapter_tier` branch.
+
+Negative:
+- Observation schema grows by ~11 fields. For a schema already tracking node identity, timing, and sensor values, this is non-trivial size increase.
+- Cross-repo schema change required in `oesis-contracts` before `oesis-runtime` can produce or consume the decision fields. Coordination overhead.
+- Runtime consumers that cached observation structure need to accept the schema additions (additive, but still a contract change).
+
+## Alternatives considered
+
+**A1: pure runtime.** Rejected because different consumers (coefficient fitting, inference, audit tooling) would each recompute admissibility from primary sources, risking inconsistent decisions. The decision needs to live once.
+
+**A2: schema carries the decision.** Rejected because any change to the 8-point check (adding a 9th, changing a threshold) would require schema migration. Historical records encoded under old rules become ambiguous. Policy is expected to evolve; schema should not.
+
+## Follow-up work
+
+- Cross-repo schema change in `oesis-contracts` v1.0 lane: extend observation schema with the 11 fact fields above. Tracked as G17.
+- Runtime implementation in `oesis-runtime` ingest: read facts, apply §C check per tier, emit decision. Tracked as G15.
+- Update `architecture/system/calibration-program.md` §C "Schema vs runtime split" subsection (already done 2026-04-19).
+- Coordinate schema migration with existing consumers; all changes are additive so forward-compat is preserved.

--- a/meta/adr/0010-adapter-trust-program-parallel-to-calibration.md
+++ b/meta/adr/0010-adapter-trust-program-parallel-to-calibration.md
@@ -1,0 +1,62 @@
+# ADR 0010: Adapter-Trust Program Parallel to Calibration Program
+
+- Status: Accepted
+- Date: 2026-04-19
+- Owners: Open Environmental Sensing and Inference System (technical)
+- Related workstreams:
+  - architecture/system/adapter-trust-program
+  - architecture/system/calibration-program
+  - release/v.0.1 (gap-register G18)
+
+## Context
+
+Capability-stage `v1.5` introduces adapter-derived evidence into first-class inference per [`../../architecture/system/node-taxonomy.md`](../../architecture/system/node-taxonomy.md) tiered acquisition model:
+
+- **Tier 1** passive inference (e.g., thermal-slope HVAC detection) — zero hardware.
+- **Tier 2** cloud-API adapters (Ecobee, Nest, Sensibo, Honeywell, etc.) — no physical power.
+- **Tier 3** direct measurement (e.g., circuit-monitor) — physical node governed by calibration-program.
+
+Tier 1 and Tier 2 evidence has fundamentally different failure modes than physical sensors:
+- Physical sensors drift due to aging, contamination, conditioning — calibration-program §D addresses this.
+- Adapters drift due to **API contract changes, credential revocation, source-authority deprecation, silent schema changes** — none of which calibration-program covers.
+
+Two options:
+
+- **B1.** Extend `calibration-program.md` with an adapter section. One doc, two concept sets.
+- **B2.** Parallel `adapter-trust-program.md` mirroring calibration-program's shape.
+- **B3.** Defer adapter posture until `v1.5` work is active.
+
+## Decision
+
+**Adopt B2: parallel adapter-trust-program.**
+
+`architecture/system/adapter-trust-program.md` mirrors `calibration-program.md` section-for-section: §A source registry, §B onboarding gate, §C admissibility, §D drift policy, §E session log, §F build-spec metadata block, §G promotion-bar compliance. Both programs produce the **same admissibility output** on normalized observations via the same decision runtime (per ADR 0009 A3), branching on `adapter_tier`.
+
+Rationale for parallel rather than merged: conflating physical-sensor failure modes with adapter-contract failure modes would force the larger vocabulary onto the smaller problem (or vice versa). Separate programs let each grow at its own pace.
+
+## Consequences
+
+Positive:
+- **Clean conceptual boundary.** Physical-sensor drift and adapter-contract drift are different problems; they get different programs with aligned structure.
+- **Parallel promotion bars.** Adapters reach `deployment maturity v1.0`/`v1.5`/`v2.0` per adapter-trust-program §G independent of physical-sensor fleet maturity.
+- **Unified admissibility output.** Both programs feed the same `admissible_to_calibration_dataset` decision on normalized observations, so downstream consumers see one concept.
+- **Scoped correctly for current work.** v0.2–v1.0 promotion involves zero adapters; program is docs-only until `v1.5` work begins. No runtime cost today.
+
+Negative:
+- **Two policy docs instead of one.** Future maintainers must remember both exist. Mitigated by cross-linking and by both docs using identical section structure.
+- **Risk of drift between the two programs.** If calibration-program §C adds a 9th admissibility check and adapter-trust-program §C doesn't, the programs fall out of sync. Mitigated by treating them as paired in any update that touches the §C check list.
+
+## Alternatives considered
+
+**B1: extend calibration-program with adapter section.**
+Rejected because calibration-program is already substantial (§A–§G, ~250 lines) and each section's logic is physical-sensor-specific. An adapter section would either repeat the structure (duplicating §A/B/C/D/E for a different concept set) or shoehorn adapter concerns into sections that were built for physical sensors. Neither is clean.
+
+**B3: defer adapter posture until v1.5 active work.**
+Rejected because `v1.5` bridge work is already being referenced across roadmap and phasing docs. Leaving the adapter program unspecified until work begins means adapter choices get designed ad-hoc and then retroactively systematized. Writing the program structure now (docs-only) costs little and ensures when `equipment-state-adapter`, `circuit-monitor` Tier 3 feed, or passive thermal-slope inference lands, they have structure to fill rather than inventing it.
+
+## Follow-up work
+
+- Populate adapter-trust-program §A source registry as adapters land (build-vault agent via proposal [`../proposals/oesis-builds-node-skeletons.md`](../proposals/oesis-builds-node-skeletons.md) Skeleton 5 for circuit-monitor).
+- Runtime admissibility branching on `adapter_tier` in `oesis-runtime` ingest per ADR 0009. Tracked as G15.
+- Cross-repo schema additions for adapter-derived observation facts in `oesis-contracts` v1.5 lane. Tracked as G17/G18.
+- Any change to calibration-program §C admissibility rule list should be mirrored in adapter-trust-program §C in the same commit to avoid drift.

--- a/meta/adr/0011-doc-discipline-extend-before-creating.md
+++ b/meta/adr/0011-doc-discipline-extend-before-creating.md
@@ -1,0 +1,64 @@
+# ADR 0011: Doc Discipline — Extend Before Creating
+
+- Status: Accepted
+- Date: 2026-04-19
+- Owners: Open Environmental Sensing and Inference System (meta)
+- Related workstreams:
+  - meta/doc-discipline
+  - meta/markdown-canonical-topic-matrix
+  - README.md (root navigation)
+
+## Context
+
+The OESIS program-specs repository contains ~200 markdown files across 6 top-level directories with per-version subdirectories under multiple roots (`legal/v0.x/`, `meta/v0.x/`, `operations/v0.x/`, `program/v0.x/`, `release/v0.x/`, `software/v0.x/`). A single week of architectural work can add 2–4 new canonical docs, 2–3 summary docs, and inline extensions to 10+ existing docs. Each addition is locally correct; cumulatively, three problems emerge:
+
+1. **Discoverability.** A new reader or session cannot tell where to start; the repo's own README assumes familiarity.
+2. **Entropy.** New concepts get new files faster than existing files get extended. No rule limits proliferation.
+3. **Consistency.** The same concept (e.g., a node's deployment posture) can live in 9 docs simultaneously with no mechanism to verify they agree.
+
+Existing guidance (`architecture/README.md` reading order, `meta/markdown-canonical-topic-matrix.md`, `meta/repo-manifest.md`) addresses narrow aspects but not the behavioral rule that keeps proliferation in check.
+
+## Decision
+
+Establish **doc discipline** as a house rule in [`../doc-discipline.md`](../doc-discipline.md). Five rules plus a 5-question new-doc checklist plus consolidation signals:
+
+1. **Extend before creating.** New concept goes into an existing doc unless genuinely cross-cutting, would blur host-doc focus, or needs citable program-level status.
+2. **Summary docs cite, don't duplicate.** Aggregator surfaces (architectural-choices-by-stage, architecture-gaps-by-stage, part sheets, release scope matrices) reference canonical values; they do not restate them. When summary and source disagree, source wins.
+3. **One canonical home per concept.** If a concept appears in ≥ 3 places, declare canonical home in `meta/markdown-canonical-topic-matrix.md`.
+4. **Per-version directories require intent.** Confirm real per-version content or real redirect need exists before creating `foo/v0.X/`.
+5. **Redirect docs self-identify** in their first line, with the canonical path.
+
+Doc discipline is complemented by:
+- Root `README.md` "Navigating this repo" section (extends existing README rather than creating `MAP.md`).
+- Per-node part sheets under `architecture/system/parts/` — aggregators that cite, not duplicate.
+
+## Consequences
+
+Positive:
+- **Proliferation slows.** Any new doc must pass the 5-question checklist; most proposed new docs become extensions.
+- **Aggregators have a pattern.** Part sheets, summary tables, and future consolidators follow rule 2 — cite upstream, don't restate — so they cannot drift.
+- **Authority is declared, not implicit.** Rule 3 means canonical ownership of overlapping topics is visible in the canonical-topic-matrix, not discovered by reader spelunking.
+- **Discipline is amendable.** Any proposal that cannot satisfy a rule goes to `architecture/decisions/debate-map.md` for amendment rather than quietly bypassing.
+
+Negative:
+- **One more thing to read.** New contributors must read doc-discipline before adding content. Mitigated by brevity (~120 lines) and the checklist being the most-cited surface.
+- **Judgment calls remain.** "Genuinely cross-cutting" is not crisp; reasonable reviewers can disagree. The checklist narrows the disagreement space but does not eliminate it.
+- **Back-compat.** Docs created before this rule may not meet rule 5 (redirect self-identification). Grandfathered — rule applies to new docs only.
+
+## Alternatives considered
+
+**No rule; rely on reviewer judgment.**
+Rejected because the rate of accumulation exceeds the rate of judgment application. Rules 2 and 3 in particular address failure modes (aggregator drift, authority confusion) that emerge only after several docs accumulate.
+
+**Automated enforcement (CI check that blocks new markdown files without a discipline-rule citation).**
+Rejected as premature. The rules are 24 hours old. Codifying them in CI locks in shape before the rules have been stress-tested. Revisit once doc-discipline has survived at least one month of use.
+
+**Stronger rule: "no new markdown files without ADR."**
+Rejected as too coarse. Part sheets and per-stage scope documents are legitimate new files that don't warrant an ADR each.
+
+## Follow-up work
+
+- Monitor discipline-rule uptake in subsequent sessions. If proposals still create files that should have extended existing docs, consider tightening rule 1.
+- Amend doc-discipline as rules prove insufficient or overly restrictive. Amendments go through `architecture/decisions/debate-map.md`.
+- Periodically audit the repo for rule-5 compliance (redirect-only docs identifying themselves in first line). Flag violations as low-severity cleanup items.
+- Consider codifying rule 1 in CI after 1–3 months if the qualitative judgment calls are stable.

--- a/meta/adr/README.md
+++ b/meta/adr/README.md
@@ -1,8 +1,71 @@
 # Architecture Decision Records
 
-Use one ADR per significant decision.
+One ADR per significant decision. ADRs are immutable records — superseded ADRs stay in place with a status change, not a delete.
 
-Suggested naming:
-- `0001-parcel-first-model.md`
-- `0002-private-by-default-data-policy.md`
-- `0003-mast-node-v0-1-sensor-stack.md`
+## Format
+
+See [`0001-template.md`](0001-template.md). Minimum sections: Status, Date, Owners, Related workstreams, Context, Decision, Consequences, Alternatives considered, Follow-up work.
+
+## When to write an ADR
+
+Per [`../doc-discipline.md`](../doc-discipline.md) rule 1, an ADR is justified when the decision:
+
+- **Changes how the system thinks about a concept** (e.g., ADR 0009: admissibility as schema-facts + runtime-decision rather than single-location)
+- **Rejects a reasonable alternative that future readers might otherwise assume was chosen** (e.g., ADR 0008: option A over option B)
+- **Sets a house rule or policy that shapes future work** (e.g., ADR 0011: doc-discipline)
+- **Commits to a non-obvious architectural split** (e.g., ADR 0010: parallel adapter-trust-program rather than extending calibration-program)
+
+If a decision is inline in prose ("decision 2026-04-19: ...") and the decision meets one of the above criteria, promote it to an ADR. Inline prose is not durable; ADRs are.
+
+## Index by number
+
+| ADR | Title | Date | Status |
+|---|---|---|---|
+| [0001](0001-bench-air-claim-boundary.md) | Bench-Air Claim Boundary | 2026-03-30 | Proposed |
+| [0002](0002-private-by-default-parcel-data.md) | Private-by-Default Parcel Data | 2026-03-30 | Proposed |
+| [0003](0003-no-public-parcel-hazard-map-in-mvp.md) | No Public Parcel Hazard Map in MVP | 2026-03-30 | Proposed |
+| [0004](0004-condition-estimate-terminology.md) | Condition Estimate Terminology | 2026-03-30 | Proposed |
+| [0005](0005-open-code-open-hardware-not-open-real-parcel-data.md) | Open Code / Open Hardware (Not Open Real Parcel Data) | 2026-03-30 | Proposed |
+| [0006](0006-project-controlled-v1-dataset-public-release.md) | Project-Controlled v1 Dataset Public Release | 2026-03-30 | Proposed |
+| [0007](0007-hazard-formula-v1-sensor-primary-log-odds.md) | Hazard Formula v1 — Sensor-Primary Log-Odds Form | 2026-04-19 | Accepted |
+| [0008](0008-mast-lite-build-spec-as-milestone-2-gate.md) | Mast-Lite Build Spec as Milestone 2 Gate (Option A) | 2026-04-19 | Accepted |
+| [0009](0009-admissibility-schema-split-facts-vs-decision.md) | Admissibility — Schema Carries Facts, Runtime Computes Decision | 2026-04-19 | Accepted |
+| [0010](0010-adapter-trust-program-parallel-to-calibration.md) | Adapter-Trust Program Parallel to Calibration Program | 2026-04-19 | Accepted |
+| [0011](0011-doc-discipline-extend-before-creating.md) | Doc Discipline — Extend Before Creating | 2026-04-19 | Accepted |
+
+## Index by domain
+
+Grouping by what the ADR decided about.
+
+### Claims and scope
+
+- [0001](0001-bench-air-claim-boundary.md) — what bench-air can and cannot claim
+- [0003](0003-no-public-parcel-hazard-map-in-mvp.md) — no public parcel-resolution map in MVP
+- [0004](0004-condition-estimate-terminology.md) — language posture (condition estimates, not directives)
+
+### Privacy and data governance
+
+- [0002](0002-private-by-default-parcel-data.md) — parcel data is private by default
+- [0005](0005-open-code-open-hardware-not-open-real-parcel-data.md) — open stack ≠ open real parcel data
+- [0006](0006-project-controlled-v1-dataset-public-release.md) — v1 dataset release posture
+
+### Inference engine
+
+- [0007](0007-hazard-formula-v1-sensor-primary-log-odds.md) — v1 hazard formula; sensor-primary log-odds
+- [0009](0009-admissibility-schema-split-facts-vs-decision.md) — where admissibility lives (schema vs runtime)
+
+### Hardware and deployment
+
+- [0008](0008-mast-lite-build-spec-as-milestone-2-gate.md) — mast-lite spec as v0.2 promotion gate
+
+### Platform programs
+
+- [0010](0010-adapter-trust-program-parallel-to-calibration.md) — adapter-trust parallel to calibration-program
+
+### Meta / house rules
+
+- [0011](0011-doc-discipline-extend-before-creating.md) — doc discipline rules
+
+## Superseded / deprecated
+
+None yet. When an ADR is superseded, change its Status to `Superseded by ADR XXXX` (do not delete) and add a new ADR that supersedes it.

--- a/meta/doc-discipline.md
+++ b/meta/doc-discipline.md
@@ -1,0 +1,104 @@
+# Doc discipline
+
+## Purpose
+
+Set house rules for when to add a new document, when to extend an existing one, and how to keep summary docs from drifting from canonical sources. The project's documentation surface is large (hundreds of markdown files across five repos) because the problem is genuinely multi-axis. Entropy is the real risk — docs accumulate faster than they consolidate. This policy slows that.
+
+## Status
+
+House rule. 2026-04-19. If a proposal contradicts a rule here, either the rule needs to evolve (amend this doc and cite the amendment) or the proposal needs to fit the rule. Do not silently bypass.
+
+## Five rules
+
+### Rule 1 — Extend before creating
+
+A new concept goes into an **existing doc** if it fits that doc's scope. Create a new file only when at least one of the following is true:
+
+- The concept is **genuinely cross-cutting** — it touches multiple existing docs and would duplicate into each.
+- Adding it in place would **blur the host doc's focus** — the host doc is about X, the concept is about Y, and Y has enough content to stand on its own.
+- The concept needs to be **citable as a program-level surface** — other docs will want to link to it by a stable name.
+
+If you can't defend a new file against all three, extend. Examples of the rule working:
+
+- New hazard-formula provenance requirement → **extended** `calibration-program.md` §C rather than creating a new admissibility doc. Correct.
+- Adapter-derived Tier 2 trust posture → **created** `adapter-trust-program.md`. Correct — genuinely parallel to calibration-program, needed citable status.
+- Per-stage architectural choices → initially drafted as inline additions across 9 stage docs; summary master was **created** as `architectural-choices-by-stage.md`. Correct — the at-a-glance need is cross-cutting.
+
+Examples of the rule being violated:
+
+- Creating `MAP.md` at repo root when the root `README.md` could host the map. That duplicates the landing-page job. Extend the README.
+
+### Rule 2 — Summary docs cite, don't duplicate
+
+Summary docs (`architecture-gaps-by-stage.md`, `architectural-choices-by-stage.md`, per-node part sheets, release scope matrices) are **aggregator surfaces**. They exist to give readers one place to check a cross-cutting question.
+
+They must not restate values that already live in canonical docs. A summary doc cell like "mast-lite IP rating: IP44" must read instead as "IP44 per `deployment-maturity-ladder.md` Deployment-class standards" with the link. The difference:
+
+- **Duplicated value** — both `architectural-choices-by-stage.md` and `deployment-maturity-ladder.md` carry "IP44" as a raw string. Drift risk: if one updates, the other doesn't.
+- **Cited value** — the summary says "IP44 per the ladder" with a link. Drift risk: the summary never drifts because the value lives once.
+
+When summary and source disagree, **source wins**. Fix the summary.
+
+### Rule 3 — One canonical home per concept
+
+If a concept appears in ≥ 3 places, declare which is canonical in `meta/markdown-canonical-topic-matrix.md`. Others cite.
+
+This is the authority-map rule. It prevents confusion when two docs describe the same thing differently.
+
+Already in the matrix:
+- Program framing (thesis/problem) → `program/operating-packet/01-core-thesis-and-framing.md` canonical; `02`, `03` redirect.
+- Target-lane roadmap/spec/taxonomy → `architecture/system/` canonical; `architecture/v1.0/` docs redirect.
+
+Add to the matrix when a new concept earns ≥ 3 locations.
+
+### Rule 4 — Per-version directories require intent
+
+Before creating `foo/v0.X/`, confirm one of:
+
+- **Real per-version content** exists — the directory will hold docs whose meaning is scoped to that version.
+- **A redirect shim is genuinely needed** — the path has existing inbound references and cannot be broken.
+
+Avoid empty scaffolding. Several per-version directories today are README-plus-stub patterns that add directory count without adding value. If you're tempted to create `operations/v0.6/README.md` that just says "lane TBD", don't.
+
+Rule of thumb: if the only thing in `foo/v0.X/` would be a README, defer creating the directory until real content exists.
+
+### Rule 5 — Redirect docs self-identify
+
+Any doc that is redirect-only must say so in its **first line**, with the canonical path. Current examples that do this correctly:
+
+- `release/v0.1/v0.1-scope-matrix.md` — opens with "Redirect Notice"
+- `architecture/future/README.md` — opens with "Future Architecture Redirect"
+
+Future redirect docs follow the same pattern. The rule prevents a reader from spending time on a redirect doc thinking it's authoritative.
+
+## Checklist before adding a new `.md` file
+
+Five questions. If any answer is "no" or "unsure", reconsider creating the file.
+
+1. **Does the concept fit an existing doc's scope?** If yes, extend the existing doc. Only create if no.
+2. **Is the concept genuinely cross-cutting, or self-contained enough to deserve citable status?** If the answer is "it depends on 2 other docs' details", it's not yet ready to stand alone.
+3. **Does a summary doc already cover this, or would a new summary duplicate?** Rule 2. Cite, don't duplicate.
+4. **Is there a canonical authority question?** If ≥ 3 docs will reference the concept, declare the canonical home in `meta/markdown-canonical-topic-matrix.md` before creating.
+5. **Will the file be content or a redirect?** If redirect-only, does its first line say so (rule 5)?
+
+## Signals that content should consolidate, not split
+
+- Two docs describe the same concept from different angles and drift over time.
+- A reader needs to read ≥ 3 docs to answer a single cross-cutting question.
+- A summary doc's cell values diverge from the canonical source.
+- A topic appears in the same form in ≥ 3 place (candidate for rule 3).
+
+When you see these, consolidate rather than add another summary.
+
+## When a rule here is wrong
+
+These rules come from cumulative experience in this repo. If a proposal cannot satisfy a rule but has clear value, amend the rule instead of quietly bypassing. Open-question entry in `architecture/decisions/debate-map.md` is the right place to debate an amendment.
+
+## Related
+
+- `repo-manifest.md` — file-level manifest
+- `markdown-canonical-topic-matrix.md` — which lane owns overlapping topics
+- `directory-versioning-destination-matrix.md` — destination rules for per-version directory content
+- `../README.md` "Navigating this repo" — where readers land; the entry surface this policy protects
+- `../architecture/README.md` — architecture-specific lane map
+- `proposals/` — pending cross-vault edit proposals (e.g., for oesis-builds, oesis-contracts)

--- a/meta/proposals/oesis-builds-calibration-program-integration.md
+++ b/meta/proposals/oesis-builds-calibration-program-integration.md
@@ -1,0 +1,162 @@
+# Proposal — Integrate calibration-program references into oesis-builds
+
+## Status
+
+Proposal. Drafted 2026-04-19. To be applied by the user via the oesis-builds build-vault agent, per the vault-scope rule in `oesis-builds/CLAUDE.md` ("Writes allowed ONLY under oesis-builds/").
+
+## Why this is a proposal, not an edit
+
+`oesis-builds/CLAUDE.md` explicitly scopes that vault's writes to itself:
+
+> **Writes allowed ONLY under `oesis-builds/`.**
+> **No writes to `oesis-hardware/`**, `oesis-wiki/`, `oesis-runtime/`, `oesis-program-specs/`, `oesis-contracts/`, or any other sibling.
+
+The symmetric implication — that external agents should respect the vault's ownership of its own content — is sound. This doc captures the edits needed so the build-vault agent (or the user directly) can apply them cleanly.
+
+## Why these edits are needed
+
+Master architecture in `oesis-program-specs` now has:
+
+- `architecture/system/calibration-program.md` — reference instrument program, burn-in gates, admissibility rule, drift policy, §F build-spec metadata block, §G promotion-bar compliance
+- `architecture/system/adapter-trust-program.md` — parallel program for Tier 1 / Tier 2 adapter-derived data
+- `architecture/system/deployment-maturity-ladder.md` — extended with power / IP / transport tier per deployment class
+- `architecture/system/sensor-placement-and-representativeness-guide.md` — extended with sensor variant selection principles
+- `architecture/system/calibration-program.md` §F — structured build-spec front-matter block that node specs must declare
+
+The oesis-builds vault is the **execution site** for calibration-program policy. Its `specs/`, `procedures/`, and `references/` directories are where the policy is exercised. Today the vault is aware of calibration infrastructure in a general way (the `references/` directory exists, calibration procedures exist) but does not reference the upstream program doc as the policy source.
+
+## Specific edits proposed
+
+### Edit 1 — `oesis-builds/README.md`
+
+**Anchor:** after the "Accuracy posture (Part E gates)" section.
+
+**Add:** new section —
+
+```markdown
+## Relationship to calibration program (upstream policy)
+
+The seven Part E gates above are this vault's **execution** of policy defined upstream in [`oesis-program-specs/architecture/system/calibration-program.md`](../oesis-program-specs/architecture/system/calibration-program.md). That program doc is canonical for:
+
+- What a "characterized reference" means (§A source of truth for reference instrument files under `references/`)
+- Burn-in gate policy per sensor family (§B — 48 h for BME680 / BME688 is the platform default)
+- Admissibility rule — whether a unit's readings can train hazard-formula coefficients or shape parcel-state claims (§C)
+- Drift response and retirement thresholds (§D)
+- Calibration log format (§E)
+- Build-spec §F metadata block — required front-matter in every `specs/<node>/v0-X.md` file
+- Promotion-bar compliance per deployment-maturity tier (§G)
+
+Adapter-derived evidence (Tier 1 passive inference, Tier 2 cloud-API adapters) is governed by the parallel [`adapter-trust-program.md`](../oesis-program-specs/architecture/system/adapter-trust-program.md). Physical sensor nodes in this vault follow calibration-program; any adapter specs that eventually land under `specs/adapters/` follow adapter-trust-program.
+
+Deployment-class standards (power tier, IP tier, transport tier) live in [`deployment-maturity-ladder.md`](../oesis-program-specs/architecture/system/deployment-maturity-ladder.md) "Deployment-class standards". Sensor variant selection principles live in [`sensor-placement-and-representativeness-guide.md`](../oesis-program-specs/architecture/system/sensor-placement-and-representativeness-guide.md).
+```
+
+### Edit 2 — `oesis-builds/GUIDE.md`
+
+**Anchor:** in Phase 0 "What to order" subsection, after the "Also order" bullet about reference instruments.
+
+**Add:** a note —
+
+```markdown
+The reference instrument program is defined upstream in [`calibration-program.md`](../oesis-program-specs/architecture/system/calibration-program.md) §A. Every reference instrument file under `references/<slug>.md` must satisfy the minimum fields named there (make, model, serial, accuracy statement, traceability chain, last verification date). The `calibrate` command refuses to run against a file that doesn't meet the schema.
+```
+
+### Edit 3 — `oesis-builds/CLAUDE.md`
+
+**Anchor:** extend the `calibrate` command description's reference instrument rule.
+
+**Replace:**
+
+```markdown
+### `calibrate <unit> [--reference <ref-slug>]`
+Walk `procedures/<node>/calibration.md`. Require a **characterized reference**: refuse if `references/<ref-slug>.md` is missing, is `TBD.md`, has `status: placeholder`, or has unpopulated accuracy fields for the parameters being calibrated. Record: date, procedure version, reference instrument (`[[references/...]]`), computed correction factors **interpreted against the spec's Uncertainty Budget** (not hardcoded thresholds), ambient conditions. Append to the Calibration section of `unit.md`. Append to the reference's `## Used by` list. A unit cannot move to `status: calibrated` unless calibration gates pass or are explicitly waived.
+```
+
+**With:**
+
+```markdown
+### `calibrate <unit> [--reference <ref-slug>]`
+Walk `procedures/<node>/calibration.md`. Require a **characterized reference** per [`calibration-program.md`](../oesis-program-specs/architecture/system/calibration-program.md) §A: refuse if `references/<ref-slug>.md` is missing, is `TBD.md`, has `status: placeholder`, or has unpopulated accuracy fields for the parameters being calibrated. The minimum-fields schema (make, model, serial, accuracy statement, traceability chain, last verification date) comes from calibration-program §A and is the contract the reference file must satisfy.
+
+Record: date, procedure version, reference instrument (`[[references/...]]`), computed correction factors **interpreted against the spec's Uncertainty Budget** (not hardcoded thresholds), ambient conditions. Append to the Calibration section of `unit.md`. Append to the reference's `## Used by` list. A unit cannot move to `status: calibrated` unless calibration gates pass or are explicitly waived.
+
+Calibration session log format follows [`calibration-program.md`](../oesis-program-specs/architecture/system/calibration-program.md) §E. Admissibility of the session's resulting readings to the OESIS calibration dataset is governed by calibration-program §C.
+```
+
+### Edit 4 — `oesis-builds/specs/bench-air-node/v0-1.md` (addresses G16)
+
+**Anchor:** front-matter — add a new YAML block at the top of the file per calibration-program §F schema.
+
+**Add:**
+
+```yaml
+---
+node_family: bench-air-node
+build_version: v0-1
+deployment_class: indoor
+deployment_maturity_target: v1.0
+measurands:
+  - name: temperature_c
+    sensor_variant: sht45-breakout-adafruit-5665
+    accuracy_statement: "±0.1 °C, 0–60 °C (per Sensirion datasheet)"
+    reference_instrument_ref: references/TBD.md  # tracked as G13
+  - name: relative_humidity_pct
+    sensor_variant: sht45-breakout-adafruit-5665
+    accuracy_statement: "±1.0 %RH, 0–100 %RH (per Sensirion datasheet)"
+    reference_instrument_ref: references/TBD.md  # tracked as G13
+  - name: gas_resistance_ohm
+    sensor_variant: bme680-breakout-adafruit-3660
+    accuracy_statement: "no absolute accuracy floor; repeatability-gated by burn-in"
+    reference_instrument_ref: null  # gas-resistance reference deferred; see calibration-program §A
+burn_in:
+  required: true
+  window_hours: 48  # BME680 platform default per calibration-program §B
+protective_fixtures: []  # indoor-only; no shield required
+transport:
+  primary: serial  # v0.1 floor per G3
+  permitted_fallbacks: []
+power:
+  source: usb
+  protection:
+    - "reverse-polarity protection (regulator-inherent)"
+calibration_program_revision: "2026-04-19"
+---
+```
+
+Rationale: v0.1 sign-off is not reopened; this front-matter block is a forward-looking declaration for v0.2 promotion per the retroactivity rule in `pre-1.0-version-progression.md`.
+
+### Edit 5 — `oesis-builds/procedures/bench-air-node/bring-up.md` (addresses G20)
+
+**Anchor:** in the acceptance-tests section, add a burn-in gate item.
+
+**Add:** a pass/fail item —
+
+```markdown
+- [ ] **Burn-in complete (calibration-program §B):** device has been powered for at least 48 continuous hours before this acceptance check, OR this unit is flagged `burn_in_complete: false` in the ingest pipeline and will not be admitted to the calibration dataset until the window elapses. Burn-in state is recorded in `build-log.md`.
+```
+
+## Application via build-vault agent
+
+To apply these edits via the build-vault agent:
+
+```bash
+cd oesis-builds
+claude
+> Apply the five edits in ../oesis-program-specs/meta/proposals/oesis-builds-calibration-program-integration.md. For each edit: read the anchor, add the proposed content exactly as written, record the application in log.md. For edit 4 (bench-air §F block), append a dated entry to decisions/ noting the forward-looking declaration per calibration-program §F.
+```
+
+The build-vault agent will respect the append-only / frozen-specs rules and produce a decision entry for the bench-air §F block change as required by the vault's own rules.
+
+## Status after application
+
+- G16 (bench-air §F block missing) → addressed by edit 4
+- G20 (bring-up doesn't enforce §B burn-in) → addressed by edit 5 at procedure level; full enforcement still requires ingest-side `burn_in_complete` flag wiring (G14 / G15)
+- G13 (reference instrument placeholder) → unchanged; edit 4's `references/TBD.md` pointer makes the dependency explicit but does not resolve it
+- Build-vault is now aware of calibration-program as the upstream policy source
+
+## Related
+
+- [`oesis-program-specs/architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md)
+- [`oesis-program-specs/architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md)
+- [`oesis-program-specs/release/v.0.1/v0.1-gap-register.md`](../../release/v.0.1/v0.1-gap-register.md) — G12 through G24
+- `oesis-builds/CLAUDE.md` — vault-scope rules

--- a/meta/proposals/oesis-builds-node-skeletons.md
+++ b/meta/proposals/oesis-builds-node-skeletons.md
@@ -1,0 +1,290 @@
+# Proposal — Skeleton build specs for five node families in oesis-builds
+
+## Status
+
+Proposal. Drafted 2026-04-19. To be applied by the user via the oesis-builds build-vault agent, per the vault-scope rule in `oesis-builds/CLAUDE.md` ("Writes allowed ONLY under oesis-builds/").
+
+Companion to [`oesis-builds-calibration-program-integration.md`](oesis-builds-calibration-program-integration.md), which covers bench-air-node specifically. This proposal covers the five remaining node families: mast-lite, flood-node, weather-pm-mast, thermal-pod, circuit-monitor.
+
+## Why this is a proposal, not an edit
+
+`oesis-builds/CLAUDE.md` scopes that vault's writes to itself. External agents (including this session) must respect the symmetric implication — the vault owns its own content. This doc captures skeletons for the build-vault agent to apply.
+
+## Why these skeletons are needed
+
+Per [`oesis-program-specs/architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §F, every node family in scope requires a `oesis-builds/specs/<node>/v0-X.md` file with a YAML front-matter metadata block. Today, only `bench-air-node` has a spec (and its §F block is covered in the companion proposal as Edit 4).
+
+Five node families have no spec at all in `oesis-builds/specs/` today:
+- `mast-lite` — blocker for v0.2 promotion (gap G12)
+- `flood-node` — v0.3 lane
+- `weather-pm-mast` — v1.0 lane
+- `thermal-pod` — research-gated
+- `circuit-monitor` — v1.5 bridge (Tier 3 direct measurement)
+
+Each skeleton below can be filled in as hardware arrives; landing the §F block now means v0.2 promotion review has a structural contract to verify against.
+
+## Schema revision
+
+All skeletons below target `calibration_program_revision: "2026-04-19"`. If [`calibration-program.md`](../../architecture/system/calibration-program.md) §F changes before these skeletons are applied, re-stamp the revision date and verify the field set.
+
+## Proposed skeletons
+
+### Skeleton 1 — `oesis-builds/specs/mast-lite/v0-1.md`
+
+Closes gap G12 (mast-lite spec missing). Deployment class: **sheltered**. Maturity target: **v1.0** (required for v0.2 promotion).
+
+```yaml
+---
+node_family: mast-lite
+build_version: v0-1
+deployment_class: sheltered
+deployment_maturity_target: v1.0
+measurands:
+  - name: temperature_c
+    sensor_variant: sht45-sintered-filter-outdoor-rated  # variant TBD; placement guide requires sintered cap or equivalent for sheltered/outdoor
+    accuracy_statement: "±0.1 °C, 0–60 °C (Sensirion datasheet); radiation-shield verification required per calibration-program §C"
+    reference_instrument_ref: references/TBD.md  # tracked as G13
+  - name: relative_humidity_pct
+    sensor_variant: sht45-sintered-filter-outdoor-rated
+    accuracy_statement: "±1.0 %RH, 0–100 %RH"
+    reference_instrument_ref: references/TBD.md  # tracked as G13
+  - name: gas_resistance_ohm
+    sensor_variant: bme680-breakout-adafruit-3660
+    accuracy_statement: "no absolute accuracy floor; repeatability-gated by burn-in; ambient humidity-sensitive in sheltered siting"
+    reference_instrument_ref: null
+burn_in:
+  required: true
+  window_hours: 48  # BME680 platform default per calibration-program §B
+protective_fixtures:
+  - name: passive radiation shield
+    acceptance_test_ref: specs/mast-lite/radiation-shield-thermal-loading-test.md  # to author
+    rationale: "Bare SHT45 outdoor readings are corrupted by solar loading; pre-shield readings inadmissible per calibration-program §C item 7"
+transport:
+  primary: serial
+  permitted_fallbacks: [wifi]
+power:
+  source: dc_12v  # or USB routed from indoor, per deployment-maturity-ladder sheltered-class defaults
+  protection:
+    - "surge protection on entry"
+    - "fused input"
+    - "strain relief on cable path"
+    - "24 h minimum buffering where ingest loss is consequential"
+calibration_program_revision: "2026-04-19"
+---
+```
+
+### Skeleton 2 — `oesis-builds/specs/flood-node/v0-1.md`
+
+v0.3 lane. Deployment class: **outdoor**. Critical fixtures: rigid mount, zero-reference, staff gauge for water-depth calibration.
+
+```yaml
+---
+node_family: flood-node
+build_version: v0-1
+deployment_class: outdoor
+deployment_maturity_target: v1.0
+measurands:
+  - name: water_depth_cm
+    sensor_variant: ultrasonic-rangefinder-outdoor-rated  # e.g. MaxBotix MB7389 or equivalent
+    accuracy_statement: "±1 cm typical; geometry-dependent; zero-reference required"
+    reference_instrument_ref: references/TBD.md  # tracked as G13; flood-node reference = staff gauge + manual depth measurement
+  - name: rise_rate_cm_per_hr
+    sensor_variant: derived  # computed from depth time-series, not a separate sensor
+    accuracy_statement: "derived metric; inherits depth accuracy; rate threshold requires documented calibration window"
+    reference_instrument_ref: null
+burn_in:
+  required: false  # ultrasonic sensors do not require conditioning
+  window_hours: null
+protective_fixtures:
+  - name: rigid mount at documented low-point
+    acceptance_test_ref: specs/flood-node/low-point-geometry-test.md  # to author
+    rationale: "Flood-node readings are only interpretable against a documented geometry; without it, depth numbers are decoration"
+  - name: zero-reference + staff gauge
+    acceptance_test_ref: specs/flood-node/zero-reference-calibration.md  # to author
+    rationale: "Without a zero-reference tied to a physical staff gauge, depth calibration is not traceable per calibration-program §A"
+transport:
+  primary: serial
+  permitted_fallbacks: [lora, wifi]
+power:
+  source: battery_solar
+  protection:
+    - "surge + transient + weather protection on entry"
+    - "fused; sealed connectors"
+    - "72 h runtime floor under worst-case solar"
+    - "retention of last observations through power events"
+calibration_program_revision: "2026-04-19"
+---
+```
+
+### Skeleton 3 — `oesis-builds/specs/weather-pm-mast/v0-1.md`
+
+v1.0 lane (second-wave outdoor). Deployment class: **outdoor**. Adds PM2.5 measurand — first node to do so.
+
+```yaml
+---
+node_family: weather-pm-mast
+build_version: v0-1
+deployment_class: outdoor
+deployment_maturity_target: v1.5  # richer outdoor lane; higher maturity target per deployment-maturity-ladder node-family maturity map
+measurands:
+  - name: pm2_5_ug_m3
+    sensor_variant: sps30-or-equivalent-laser-scattering-sensor  # variant TBD
+    accuracy_statement: "±10 μg/m³ or ±10 % (whichever greater) per EPA AQS; EPA AirNow cross-check required at onboarding"
+    reference_instrument_ref: references/TBD.md  # tracked as G13; PM reference = collocated EPA AQS reference monitor or equivalent
+  - name: temperature_c
+    sensor_variant: sht45-sintered-filter-outdoor-rated
+    accuracy_statement: "±0.1 °C, 0–60 °C; radiation-shield verification required"
+    reference_instrument_ref: references/TBD.md
+  - name: relative_humidity_pct
+    sensor_variant: sht45-sintered-filter-outdoor-rated
+    accuracy_statement: "±1.0 %RH"
+    reference_instrument_ref: references/TBD.md
+  - name: pressure_hpa
+    sensor_variant: bme280-or-equivalent  # TBD
+    accuracy_statement: "±1 hPa"
+    reference_instrument_ref: references/TBD.md
+  - name: wind_speed_m_s
+    sensor_variant: cup-anemometer-or-ultrasonic  # TBD
+    accuracy_statement: "TBD"
+    reference_instrument_ref: references/TBD.md
+burn_in:
+  required: true
+  window_hours: 48  # PM sensor conditioning + airflow stabilization
+protective_fixtures:
+  - name: radiation shield + PM airflow module
+    acceptance_test_ref: specs/weather-pm-mast/airflow-acceptance-test.md  # to author
+    rationale: "PM readings distorted without proper airflow; temperature readings distorted without radiation shield"
+transport:
+  primary: wifi
+  permitted_fallbacks: [lora, cellular]
+power:
+  source: mains_outdoor_psu
+  protection:
+    - "outdoor-rated PSU routed through conduit"
+    - "surge + transient + weather protection on entry"
+    - "sealed connectors; corrosion-aware hardware"
+    - "72 h runtime floor via UPS where mains reliability warrants"
+calibration_program_revision: "2026-04-19"
+---
+```
+
+### Skeleton 4 — `oesis-builds/specs/thermal-pod/v0-1.md`
+
+Research-gated lane. Deployment-maturity target deliberately below `v1.0` until scene + privacy posture clears; marked `research_gated: true` so admissibility tooling can reject readings from this family for production coefficient fits.
+
+```yaml
+---
+node_family: thermal-pod
+build_version: v0-1
+deployment_class: outdoor  # fixed scene; research-gated
+deployment_maturity_target: v0.1  # intentionally kept at bench prototype until contract + privacy posture clears
+research_gated: true  # flag: readings from research-gated families are inadmissible to production calibration datasets per calibration-program §C
+measurands:
+  - name: scene_thermal_c_grid
+    sensor_variant: mlx90640-or-equivalent-32x24-thermal-array  # TBD
+    accuracy_statement: "±1–2 °C absolute; relative resolution sufficient for scene gradient detection; emissivity-dependent"
+    reference_instrument_ref: references/TBD.md  # thermal-scene reference = co-located hand-held IR thermometer + emissivity documentation
+burn_in:
+  required: true
+  window_hours: 24  # thermal arrays require post-power-on warmup for stable offset
+protective_fixtures:
+  - name: hooded enclosure with documented field-of-view
+    acceptance_test_ref: specs/thermal-pod/fov-privacy-review.md  # to author; privacy review required
+    rationale: "Privacy-reviewed field-of-view is a prerequisite for any reading to be admissible; uncontrolled FOV risks surveillance drift per vision-and-use-cases.md"
+transport:
+  primary: wifi
+  permitted_fallbacks: []
+power:
+  source: mains_outdoor_psu
+  protection:
+    - "Raspberry Pi with durable local storage"
+    - "clean shutdown posture"
+calibration_program_revision: "2026-04-19"
+---
+```
+
+### Skeleton 5 — `oesis-builds/specs/adapters/circuit-monitor/v0-1.md`
+
+**Note:** circuit-monitor is an **adapter** (Tier 3 direct measurement per [`node-taxonomy.md`](../../architecture/system/node-taxonomy.md) tiered acquisition model) — not a parcel-sensing hardware node. Its spec should land under `oesis-builds/specs/adapters/circuit-monitor/v0-1.md`, and it is governed by [`adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §F rather than calibration-program §F.
+
+Flag for the build-vault agent: the `specs/adapters/` subtree may not exist yet. Create it if needed; it will become the home for every future adapter spec.
+
+```yaml
+---
+adapter_family: circuit-monitor
+build_version: v0-1
+tier: tier_3_direct  # direct measurement of current draw via CT clamps
+source_authority_ref: procedures/adapters/circuit-monitor/source.md  # to author; source = PZEM-004T/016 module reading CT clamp current at configured panel circuit
+pinned_contract_version: pzem-004t-v3-serial  # pinned firmware + protocol version
+measurands:
+  - name: hvac_mode
+    source_field: derived_from_current_draw_pattern
+    expected_type: enum  # off | fan_only | cool | heat | recirc (where distinguishable)
+    uncertainty_bound: "HIGH confidence for on/off; MEDIUM for mode distinction"
+    tier_3_cross_check_ref: null  # self is tier 3; no higher tier available
+  - name: sump_state
+    source_field: derived_from_current_draw_pattern
+    expected_type: enum  # off | running
+    uncertainty_bound: "HIGH confidence for on/off"
+    tier_3_cross_check_ref: null
+  - name: equipment_running
+    source_field: boolean_from_current_above_threshold
+    expected_type: bool
+    uncertainty_bound: "HIGH confidence"
+    tier_3_cross_check_ref: null
+  - name: power_draw_w
+    source_field: pzem_power_w
+    expected_type: number
+    uncertainty_bound: "±1 % per PZEM-004T datasheet"
+    tier_3_cross_check_ref: null
+onboarding_requirements:
+  cross_check_against_tier_3: false  # this IS tier 3
+  initial_verification_window_hours: 24
+credential_model:
+  type: none  # direct serial; no cloud auth required
+  scope: "local serial port"
+  refresh_cadence_hours: null
+deployment_maturity_target: v1.5  # v1.5 bridge hardware
+# Physical posture (even though this is an adapter, the CT clamp device has physical posture):
+physical_posture:
+  deployment_class: indoor  # mains-adjacent, inside electrical panel or near it
+  power_source: low_power_from_measured_circuit
+  ip_tier: electrical_enclosure_ip20
+  transport: wifi
+  protective_fixtures:
+    - name: electrical-code-compliant CT clamp installation
+      acceptance_test_ref: specs/adapters/circuit-monitor/installation-code-compliance.md  # to author
+      rationale: "Installation on live mains circuits requires licensed electrician in many jurisdictions; code compliance is a prerequisite for deployment"
+adapter_trust_program_revision: "2026-04-19"
+---
+```
+
+## Application via build-vault agent
+
+```bash
+cd oesis-builds
+claude
+> Apply the five skeletons in ../oesis-program-specs/meta/proposals/oesis-builds-node-skeletons.md.
+> For each skeleton: create the target file (specs/<node>/v0-1.md or specs/adapters/<adapter>/v0-1.md), paste the YAML front-matter block exactly as written, add minimum body content (Overview, BOM-as-specified, Wiring, Firmware, Procedures, Acceptance tests, Linked decisions sections as per the _templates/spec.md skeleton), and record a decision entry under decisions/<node>/ noting the forward-looking §F declaration.
+> Flag for circuit-monitor specifically: ensure specs/adapters/ subtree exists; circuit-monitor is governed by adapter-trust-program.md not calibration-program.md.
+```
+
+The build-vault agent will respect the frozen-specs / append-only rules. Each skeleton's missing acceptance-test references (`acceptance_test_ref`) become TODOs under `specs/<node>/` that the agent can either author inline or mark as pending.
+
+## Status after application
+
+- **G12** (mast-lite spec missing) → addressed by Skeleton 1 at structural level; full resolution requires hardware bring-up + reference instrument population + radiation-shield test authoring.
+- **New structural presence** for flood-node, weather-pm-mast, thermal-pod, circuit-monitor in `oesis-builds/specs/` (or `specs/adapters/` for circuit-monitor) — each declares deployment posture in a machine-greppable form.
+- **G13** (reference instruments) — unchanged; every skeleton's `reference_instrument_ref: references/TBD.md` makes the dependency explicit per family.
+- **G14** (burn-in) — enforced structurally for BME680-bearing nodes (mast-lite, weather-pm-mast) and for thermal arrays (thermal-pod).
+- **Per-family posture declarations** match the defaults in [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) "Deployment-class standards" and the summary table in [`integrated-parcel-system-spec.md`](../../architecture/system/integrated-parcel-system-spec.md) "Deployment posture per node".
+
+## Related
+
+- [`oesis-builds-calibration-program-integration.md`](oesis-builds-calibration-program-integration.md) — companion proposal for bench-air-node and vault-level integration
+- [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §F schema
+- [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §F schema (for circuit-monitor)
+- [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) — class / power / IP / transport defaults
+- [`../../architecture/system/integrated-parcel-system-spec.md`](../../architecture/system/integrated-parcel-system-spec.md) — hardware role map + deployment posture summary
+- [`../../release/v.0.1/v0.1-gap-register.md`](../../release/v.0.1/v0.1-gap-register.md) — G12, G13, G14, G18
+- `oesis-builds/CLAUDE.md` — vault-scope rules

--- a/meta/repo-manifest.md
+++ b/meta/repo-manifest.md
@@ -38,8 +38,28 @@
 - `architecture/system/canonical-links.md`
 - `architecture/system/integrated-parcel-system-spec.md`
 - `architecture/system/architecture-gaps-by-stage.md`
+- `architecture/system/architectural-choices-by-stage.md`
+- `architecture/system/calibration-program.md`
+- `architecture/system/adapter-trust-program.md`
 - `architecture/system/deployment-maturity-ladder.md`
 - `architecture/system/phase-roadmap.md`
+- `architecture/system/parts/README.md`
+- `architecture/system/parts/bench-air-node.md`
+- `architecture/system/parts/mast-lite.md`
+- `architecture/system/parts/flood-node.md`
+- `architecture/system/parts/weather-pm-mast.md`
+- `architecture/system/parts/thermal-pod.md`
+- `architecture/system/parts/circuit-monitor.md`
+- `meta/doc-discipline.md`
+- `meta/adr/0007-hazard-formula-v1-sensor-primary-log-odds.md`
+- `meta/adr/0008-mast-lite-build-spec-as-milestone-2-gate.md`
+- `meta/adr/0009-admissibility-schema-split-facts-vs-decision.md`
+- `meta/adr/0010-adapter-trust-program-parallel-to-calibration.md`
+- `meta/adr/0011-doc-discipline-extend-before-creating.md`
+- `meta/proposals/oesis-builds-calibration-program-integration.md`
+- `meta/proposals/oesis-builds-node-skeletons.md`
+- `software/inference-engine/hazard-formula-v1.md`
+- `software/inference-engine/hazard-formula-v1-phase1.md`
 - ~~`hardware/`~~ — **Moved to [oesis-hardware](https://github.com/lumenaut-llc/oesis-hardware)**
 - ~~`contracts/`~~ — **Moved to [oesis-contracts](https://github.com/lumenaut-llc/oesis-contracts)** (lane directories v0.1–v1.5, plus top-level `examples/` and `schemas/`)
 - ~~`artifacts/contracts-bundle/`~~ — **Moved to [oesis-contracts/bundles/contracts-bundle/](https://github.com/lumenaut-llc/oesis-contracts/blob/main/bundles/contracts-bundle/)**

--- a/operations/pilots/first-block-pilot.md
+++ b/operations/pilots/first-block-pilot.md
@@ -32,3 +32,17 @@ Validate parcel-level usefulness under partial adoption.
 - document operator access expectations
 - document what data may be published, aggregated, or exported
 - define who handles complaints, revocation requests, and incident escalation
+
+## Calibration-program compliance (gap register G19)
+
+Per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §G and [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md) promotion-bar item 5, **external pilots require every deployed node family to meet `deployment maturity v1.0` calibration posture**. This is a hard gate per G19 in [`../../release/v.0.1/v0.1-gap-register.md`](../../release/v.0.1/v0.1-gap-register.md); unmet means no external pilot.
+
+Concrete checks per deployed unit before pilot enrollment:
+
+- Node's build spec at `oesis-builds/specs/<node>/v0-X.md` carries a §F metadata block per calibration-program §F (or adapter-trust-program §F for Tier 2/3 adapters).
+- At least one characterized reference instrument is populated per measurand per deployment class under `oesis-builds/procedures/<node>/references/`. Placeholder `references/TBD.md` is not acceptable for external pilot (G13).
+- BME680-bearing nodes have completed the 48 h burn-in window; `burn_in_complete: true` either by ingest flag (when G14/G15 ship) or by build-log attestation before the flag is wired.
+- For outdoor-class nodes (flood-node, weather-pm-mast), protective-fixture acceptance tests (radiation shield, zero-reference/geometry) have passed per calibration-program §C item 7; pre-verification readings are excluded from pilot data.
+- For adapters (circuit-monitor Tier 3 direct, or future Tier 2 cloud adapters), source-authority onboarding per [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §B completed for each participating parcel.
+
+If any condition is not met, the pilot must either wait, exclude the affected node family, or document an explicit stop-ship-override decision approved by the governance owner. Internal reference runs (Tier A per [`../../release/v.0.1/v0.1-pilot-minimum-subset.md`](../../release/v.0.1/v0.1-pilot-minimum-subset.md)) have a weaker bar — calibration-posture attestation is recommended but not gating for Tier A.

--- a/program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md
+++ b/program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md
@@ -63,6 +63,15 @@ One parcel, one bench-air lineage, one ingest path, one inference path, one parc
 
 Can we honestly produce a parcel view from one observation path?
 
+### Required deployment posture
+
+- **Deployment-maturity tier:** `v0.1` (bench prototype) per [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md).
+- **Deployment class set:** indoor only.
+- **Power tier:** USB.
+- **IP tier:** none / IP20.
+- **Transport tier:** serial-only (v0.1 floor per gap register G3).
+- **Calibration rigor:** provisional per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §G at the `v0.1` tier; characterized references not required; readings not admissible to calibration dataset.
+
 ## `v1.0` — first broader fielded parcel-intelligence lane
 
 ### Core goal
@@ -102,6 +111,16 @@ Program milestones already describe the next hardware step as **indoor plus shel
 ### Success question
 
 Can we produce a more trustworthy parcel state from a real parcel kit and limited shared evidence?
+
+### Required deployment posture
+
+- **Deployment-maturity tier:** `v1.0` (first fielded kit) per [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md). Promotion bar item 5 in [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md) requires calibration-program §G compliance at this tier for every shipped node family.
+- **Deployment class set:** indoor + sheltered (adds `mast-lite`); outdoor class enters through flood-node (`v0.3`) and later weather-pm-mast.
+- **Power tier:** USB for indoor; 12V-DC or USB routed from indoor for sheltered; battery+solar or hardened mains for outdoor.
+- **IP tier:** IP20 indoor / IP44 sheltered / IP65 outdoor.
+- **Transport tier:** serial as floor; Wi-Fi permitted for sheltered and outdoor; LoRa / cellular permitted for outdoor beyond Wi-Fi reach. All transports preserve the `oesis.bench-air.v1` lineage; transport choice does not alter schema.
+- **Protective fixtures:** radiation shield required for any outdoor temperature reading (mast-lite, weather-pm-mast); rigid mount + zero reference + staff gauge for flood-node. Pre-verification readings excluded from calibration dataset per calibration-program §C.
+- **Calibration rigor:** characterized reference instruments populated per measurand per deployment class (gap G13); burn-in gate enforced for BME680-bearing nodes (gap G14); §F build-spec metadata block present for every node family (gap G16 for bench-air, G12 for mast-lite).
 
 ## `v1.5` — measurement-to-intervention bridge (capability stage, not a promoted runnable slice)
 
@@ -182,6 +201,13 @@ At least one product path should support:
 `hazard -> house state -> action -> measured outcome`
 
 without pretending that every action is automated or that the system already has a mature adaptation engine.
+
+### Required deployment posture
+
+- **Deployment-maturity tier:** `v1.5` (trust hardening) per [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md); versioned calibration state, drift-aware offsets, maintenance-informed trust penalties expected.
+- **Deployment class set:** adds indoor bridge surfaces. `indoor-response-node` (indoor / USB / IP20 / Wi-Fi); `power-outage-node` (indoor / **battery-backed** — intrinsic to use case); `circuit-monitor` (mains-adjacent / low-power from measured circuit / electrical-enclosure IP20 / Wi-Fi).
+- **Adapter-derived data enters first-class:** Tier 1 passive inference (e.g., thermal-slope), Tier 2 cloud-API adapters (Ecobee, Nest, Sensibo, etc.), Tier 3 direct measurement (circuit-monitor). Governed by [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) — parallel program to calibration-program for adapters. Every adapter declares source authority, pinned API contract version, onboarding gate, cross-check posture.
+- **Calibration rigor:** physical-sensor nodes at calibration-program §G `v1.5` tier (versioned offsets); adapter-derived data at adapter-trust §G `v1.5` tier (verification logs versioned, schema-drift detection active).
 
 ### What still stays out
 

--- a/release/v.0.1/v0.1-gap-register.md
+++ b/release/v.0.1/v0.1-gap-register.md
@@ -12,9 +12,9 @@ Classify gaps uncovered during the v0.1 completeness review (2026-04-08) as **v0
 
 | ID | Gap | Severity | Owner (default) | Next artifact |
 | --- | --- | --- | --- | --- |
-| G1 | Named BOM vendors / SKU-level procurement (matrix already flags) | Defer for lab v0.1; **Blocker** for naive third-party kitting | Release / hardware | `integrated-parcel-kit-bom.md` + checklist: add preferred suppliers or “bring your own” rules |
+| G1 | Named BOM vendors / SKU-level procurement (matrix already flags); also now includes reference instruments per `architecture/system/calibration-program.md` §A since reference-instrument files under `oesis-builds/procedures/<node>/references/` are de facto BOM items | Defer for lab v0.1; **Blocker** for naive third-party kitting | Release / hardware | `integrated-parcel-kit-bom.md` + checklist: add preferred suppliers or "bring your own" rules; reference-instrument rows per measurand per deployment class per `calibration-program.md` §A |
 | G2 | Ingest authorization + strong parcel binding for live nodes | Defer | Technical | Design note + API hooks; matrix row already tracks |
-| G3 | Continuous Wi-Fi (or other) transport from node to ingest with TLS, identity, retries | Defer | Technical | Spec transport lane; v0.1 assumes serial extract or HTTP demo with manual packet |
+| G3 | Continuous Wi-Fi (or other) transport from node to ingest with TLS, identity, retries | Defer | Technical | Transport lane now defined per deployment class in `architecture/system/deployment-maturity-ladder.md` "Transport tier by deployment class"; v0.1 assumes serial extract or HTTP demo with manual packet; v0.2 and later inherit class-appropriate transport from that table rather than re-deciding here |
 | G4 | Real public weather/smoke feeds (keys, rate limits, fallbacks) | Defer | Technical | Operator doc for env vars / adapters when leaving fixtures |
 | G5 | Consumer app, push alerts (FR4), event timeline UI | PRD-only | Product | Out of v0.1; see `v0.1-scope-matrix.md` |
 | G6 | Revocation / consent / sharing as enforceable product guarantees | PRD-only for pilot; Defer for reference | Governance / technical | `launch-readiness-checklist.md` stop-ship items if external pilot |
@@ -22,6 +22,89 @@ Classify gaps uncovered during the v0.1 completeness review (2026-04-08) as **v0
 | G8 | `v1.0` runtime lane differs minimally from v0.1 offline check today | Defer (clarity) | Technical | Document deltas as files appear under `oesis/assets/v1.0/` |
 | G9 | Field install photos / long-run bench evidence | Defer | Operations | Controlled review folder per matrix |
 | G10 | PRD hazard claims vs bench-air-only sensing (flood, outage, freeze) | **Blocker** for marketing as full hazard suite; **Defer** for honest reference | Release + technical | Copy + scope matrix alignment; inference stays conservative |
+| G11 | Hazard probability formula (smoke, heat) is v0 band heuristic without provenance, calibration, or sensor-primacy contract; numbers in `config/hazard_thresholds_v0.json` and `parcel_prior_rules_v0.json` lack cited sources | Defer (program-phase `v0.2` / Milestone 2; capability stage `current v1`) | Technical | Adopt `software/inference-engine/hazard-formula-v1.md`: shadow v1 log-odds formula alongside v0, device-relative gas-resistance baseline, provenance schema on every numeric entry, divergence channels against public/shared context, Brier/ECE calibration gate against pilot labels |
+| G12 | `mast-lite` has no build spec, calibration procedure, BOM, or radiation-shield spec in `oesis-builds/`; hazard formula v1 primary heat path and milestone-roadmap Milestone 2 both assume it exists in buildable form | **Blocker** for v1 heat primary path | Hardware | **Decision 2026-04-19 (option A):** write `oesis-builds/specs/mast-lite/v0-1.md` with BOM + wiring + firmware + reproducible build, `oesis-builds/procedures/mast-lite/calibration.md` with a characterized reference instrument, and a radiation-shield design with thermal-loading acceptance test inside the build spec. Build must be independently reproduced once before Milestone 2 promotion. Documented as `Phase 0.3` in `software/inference-engine/hazard-formula-v1-phase1.md`; gate items added to Milestone 2 acceptance in `architecture/current/milestone-roadmap.md` |
+| G13 | Calibration procedure `oesis-builds/procedures/bench-air-node/calibration.md` requires a characterized reference instrument, but `references/TBD.md` is a placeholder; no unit has been calibrated against a real referent; v1 coefficient fits would be statistically precise but physically meaningless | **Blocker** for v1 coefficient fitting; Defer for v0 bands | Hardware | Populate at least one reference instrument per measurand per deployment class per `architecture/system/calibration-program.md` §A; file format and minimum fields specified there. Operationalized as `Phase 0.1` in `software/inference-engine/hazard-formula-v1-phase1.md` |
+| G14 | BME680 burn-in (24–48 h) not enforced as a gate in bring-up acceptance; `oesis-builds/specs/bench-air-node/v0-1.md:211` checks "trending gradually" as posture, not as a calibration-admission gate; first-48h data of any device would contaminate baseline fits | **Blocker** for v1 gas-resistance coefficient fitting; Defer for v0 bands | Hardware + technical | Enforce burn-in gate per `architecture/system/calibration-program.md` §B (48 h platform default for BME680/BME688); ingest pipeline tags observations as `burn_in_complete: false` until window passes; admissibility rule in §C excludes pre-burn-in readings from coefficient fits. Operationalized as `Phase 0.2` in `software/inference-engine/hazard-formula-v1-phase1.md` |
+| G15 | Admissibility rule in `architecture/system/calibration-program.md` §C is `planned`, not `implemented`; ingest pipeline cannot enforce the 8-point admissibility check, and §F build-spec front-matter metadata block is human-readable contract only — no automated validation against deployment-class standards in `deployment-maturity-ladder.md`; §G promotion-bar compliance relies on manual review | Defer (program-phase `v0.2` / Milestone 2) | Technical | Two parts: (1) ingest adds `admissible_to_calibration_dataset: bool` + reason list on each normalized observation, wiring in all 8 §C checks against per-device calibration state and build-spec declarations; (2) front-matter validator reads §F block from `oesis-builds/specs/<node>/v0-X.md`, validates against `deployment-maturity-ladder.md` class standards, fails loudly on exceptions without justification. Both gate `v0.2` promotion via the 5th item in `../../architecture/current/pre-1.0-version-progression.md` promotion bar |
+| G16 | Bench-air build spec `oesis-builds/specs/bench-air-node/v0-1.md` predates the §F front-matter schema in `architecture/system/calibration-program.md` and lacks the structured metadata block; `v0.2` promotion bar requires bench-air at `deployment maturity v1.0` per `pre-1.0-version-progression.md` retroactivity rule, which requires the block | Defer (program-phase `v0.2` / Milestone 2) | Hardware + technical | Add the §F YAML front-matter block to bench-air build spec, declaring deployment_class (`indoor`), deployment_maturity_target (`v1.0`), measurands (temperature_c, relative_humidity_pct, gas_resistance_ohm), sensor variants, reference_instrument_refs (pending G13), burn_in parameters (required: true, window_hours: 48 per G14), transport (serial per G3 floor), power (usb for v0.1; re-evaluate for v0.2 per deployment-class-standards). v0.1 sign-off is not reopened; block is a forward-looking declaration for v0.2 |
+| G17 | Canonical observation schema in `oesis-contracts` lacks the facts that `architecture/system/calibration-program.md` §C admissibility check and `architecture/system/adapter-trust-program.md` §C admissibility check both depend on; without schema presence, every downstream consumer recomputes admissibility differently or the decision loses its audit trail | **Blocker** for G15 admissibility tooling; defer only if G15 is deferred | Technical (cross-repo) | Extend observation schema in `oesis-contracts` to include: `burn_in_complete`, `node_calibration_session_ref`, `node_deployment_maturity`, `node_deployment_class`, `protective_fixture_verified_at`, `placement_representativeness_class` (physical sensors per calibration-program §C); plus `adapter_source_ref`, `adapter_contract_version`, `adapter_onboarding_ref`, `adapter_credential_last_verified_at`, `adapter_tier` (adapter-derived per adapter-trust-program §C). Decision 2026-04-19: schema carries facts, runtime computes decision (A3). Admissibility decision fields `admissible_to_calibration_dataset` and `admissibility_reasons` live on the normalized observation only, never back-propagated to schema |
+| G18 | Adapter-trust-program.md exists as policy for Tier 1 / Tier 2 adapter-derived evidence, but no adapter spec, source authority file, onboarding verification, or session log exists; `v1.5` bridge surfaces (equipment-state-adapter, indoor-response-node, passive thermal-slope inference) depend on this program being populated | Defer (capability stage `v1.5`) | Technical + hardware | As `v1.5` bridge work lands, populate `oesis-builds/specs/adapters/<adapter>/v0-1.md` with §F front-matter, `oesis-builds/procedures/adapters/<adapter>/source.md` with §A source authority file, and per-parcel onboarding verification records. Runtime admissibility tooling from G15 must branch on `adapter_tier` field to apply adapter-trust-program §C rather than calibration-program §C for non-direct-measurement evidence |
+| G19 | `release/v.0.1/v0.1-pilot-minimum-subset.md` Tier A / Tier B pilot gating does not include calibration-program compliance or adapter-trust-program compliance as stop-ship triggers; an external pilot could currently ship with nodes lacking §F blocks, stale reference calibration, or unverified radiation shields | **Blocker** for any external pilot in v0.2 or later; Defer for internal-only reference runs | Governance + release | Extend Tier B pilot gates to include: (a) every deployed node has a §F front-matter block; (b) every deployed node meets at least `deployment maturity v1.0` calibration posture per calibration-program §G; (c) every adapter in use meets `deployment maturity v1.0` adapter-trust posture per adapter-trust-program §G; (d) no node's reference-calibration state is beyond its re-verification cadence |
+| G20 | `oesis-builds/procedures/bench-air-node/bring-up.md` and `procedures/_shared/installation-checklist.md` do not enforce the §B burn-in gate or verify the build spec's §F block matches physical installation; operator can currently complete bring-up with a node that fails §C admissibility | Defer (program-phase `v0.2` / Milestone 2) | Operations + hardware | Add pass/fail items to bring-up: (a) §F block present and declared deployment_class matches installation site; (b) burn-in window elapsed before bring-up is signed off; (c) reference-calibration session for this unit on record if already required by its deployment-maturity target; (d) protective-fixture acceptance test passed where §F declares one |
+| G21 | No CI or automated check validates §F front-matter blocks in `oesis-builds/specs/<node>/` against deployment-class standards in `deployment-maturity-ladder.md`, nor tracks calibration-posture regressions across slice promotions; §G compliance rests on manual review | Defer (v0.2+; ships with G15 tooling) | Technical | CI job (location tbd; likely `oesis-builds` or `oesis-program-specs`) that (a) parses every build spec's §F block, (b) validates field values against `deployment-maturity-ladder.md` class standards, (c) flags exceptions lacking justification sections, (d) on slice-promotion review, runs calibration-posture comparison against prior slice and reports regressions. Shares code with G15 runtime validator where possible |
+| G22 | `shared-map-product-posture.md` and `neighborhood-signal-transformation-overview.md` do not gate shared-layer participation on calibration posture or adapter-trust posture; a well-placed but uncalibrated node can currently dilute shared neighborhood truth | Defer (Milestone 5 / `v0.5` governance slice) | Technical + governance | Extend shared-layer eligibility rule in `sensor-placement-and-representativeness-guide.md` ("shared-layer participation should depend partly on placement quality") to add calibration and adapter-trust posture as preconditions. Concrete rule: contribution to shared-map aggregation requires the contributing node's most recent observation to be admissible per calibration-program §C or adapter-trust-program §C, whichever applies |
+| G23 | `oesis-runtime/oesis/assets/v0.5/config/inference/parcel_prior_rules_v0.json` and `config/hazard_thresholds_v0.json` have no provenance slots; `hazard-formula-v1.md` provenance schema is a v1 requirement, but existing v0 config cannot be tagged without reopening v0.1 sign-off | Defer (program-phase `v0.2` bench-air retroactivity via promotion-bar item 5) | Technical | Add provenance envelope to existing v0 config files as part of v0.2 forward work; v0.1 signed config stays untagged for audit integrity. Schema: every numeric entry gains `value`, `source`, `source_type`, `date`, `note`; validator in G15 rejects untagged numbers once enforced. Coupled to G11's v1 adoption path |
+| G24 | Product-surface evidence summary (reference implementation in parcel view JSON; product UX later) does not expose calibration-state or admissibility reason codes to downstream consumers; a user cannot currently tell why a reading was excluded from inference or why confidence dropped | PRD-only for v0.2; Defer for pre-v1.5 | Product + technical | Evidence summary gains: per-observation `admissibility_reasons` passthrough; per-parcel summary of admissibility rate and calibration posture; when confidence is degraded by calibration state, a reason string from a controlled vocabulary. Waits for the v1.5 evidence-view product surface where this becomes user-facing |
+
+## Pivot views
+
+The gap table above is the canonical record; rows are flat and time-ordered (G1 is oldest, G24 is newest). The views below are **aggregator pivots** — they cite the same rows from different angles so a reader asking "which gaps block v0.2?" or "what's affected if G13 stays open?" can answer in one place. Per [`../../meta/doc-discipline.md`](../../meta/doc-discipline.md) rule 2, these views do not restate gap content; they group by reference.
+
+### By promotion bar
+
+Which gaps block which slice promotion, per the 5-item bar in [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md):
+
+| Slice / phase | Must clear | Optional / deferrable |
+|---|---|---|
+| `v0.1` sign-off (2026-04-08) | — (already signed off) | G1–G10 deferred per severity column |
+| **`v0.2` (Milestone 2) promotion** | **G11** (formula), **G12** (mast-lite spec), **G13** (reference instruments), **G14** (burn-in gate), **G16** (bench-air §F block), **G17** (observation-schema facts), **G23** (runtime config provenance) | G15 (admissibility tooling — can ship in shadow), G20 (bring-up gates enforceable via §F posture), G21 (CI validation — can be manual initially) |
+| `v0.3` (flood) | inherits v0.2 bar; no new blockers filed | — |
+| `v0.4` (multi-node registry) | inherits v0.2 bar | — |
+| `v0.5` (governance) | **G19** (pilot gates) for any external pilot; **G22** (shared-layer eligibility gating) | — |
+| `v1.0` (pre-1.0 ladder "materially broader") | full calibration-program §G compliance fleet-wide (all bar items cleared for every shipped node family) | G24 (product-surface admissibility reasons — PRD-only) |
+| `v1.5` (capability-stage bridge) | **G18** (adapter-trust program execution) | — |
+
+For v0.2 specifically: see the "Dependency chain" below for the critical path through G11 → G13 → G14 → G17 → G15.
+
+### By affected node family
+
+Which gaps each node family's part sheet ([`../../architecture/system/parts/`](../../architecture/system/parts/)) references:
+
+| Node family | Gaps that involve it |
+|---|---|
+| `bench-air-node` | G13, G14, G16, G23 |
+| `mast-lite` | **G12** (primary blocker), G13, G14, G17 |
+| `flood-node` | G10, G13, G17 |
+| `weather-pm-mast` | G13, G17 |
+| `thermal-pod` | — (research-gated; non-blocking) |
+| `circuit-monitor` | G17, G18 |
+
+### By owner
+
+Which team or workstream owns each gap's remediation:
+
+| Owner column | Gaps |
+|---|---|
+| Hardware | G1, G12, G13, G16 (shared), G20 (shared) |
+| Technical | G2, G3, G4, G7, G8, G10 (shared), G11, G15, G17, G21, G24 (shared) |
+| Hardware + technical | G14, G16 (shared), G18, G20 (shared), G22 (shared) |
+| Governance / release | G6, G19, G22 (shared) |
+| Product | G5, G24 (shared) |
+| Operations | G9 |
+
+### Dependency chain (critical path for v0.2)
+
+Where one gap must clear before another is useful. Arrow = "blocks":
+
+- **G13 (reference instruments)** → **G14 (burn-in gate)** — burn-in gate is enforceable only if there is something characterized to compare against.
+- **G13 → G16 (bench-air §F block)** — §F's `reference_instrument_ref` field needs a non-TBD target.
+- **G17 (observation-schema facts)** → **G15 (admissibility tooling)** — runtime cannot compute admissibility decisions without the schema facts to consume.
+- **G13 → G15** — and the schema facts themselves need populated references to refer to.
+- **G15 → coefficient fitting** for the hazard-formula-v1 work (G11) — formula coefficients cannot train on admissible data until the runtime is emitting admissibility decisions.
+- **G12 (mast-lite spec)** → **G17** for the sheltered-outdoor observation facts specific to mast-lite; mast-lite's §F block must declare values before schema writes those fields.
+
+**Shortest critical path to "v1 formula coefficient fits can start":** G13 → G14 → (G16 and G17 in parallel) → G15 → G11 proceeds. Roughly five sequential steps; G12 lands in parallel as a mast-lite blocker on the same v0.2 promotion.
+
+### By status (rough posture, not authoritative)
+
+- **Blocker for v0.2 promotion:** G11, G12, G13, G14, G16, G17, G23
+- **Blocker for v1 formula fitting** (subset of above): G13, G14, G15, G17
+- **Blocker for external pilot** (regardless of slice): G19
+- **Defer (v1.5 or later):** G18, G22
+- **PRD-only:** G5, G6, G24
+
+Status is rough — the severity column in the main table is the authoritative source when it disagrees with this summary.
 
 ## Hardware traceability (2026-04-08)
 

--- a/release/v.0.1/v0.1-osi-diagrams-text.md
+++ b/release/v.0.1/v0.1-osi-diagrams-text.md
@@ -22,6 +22,18 @@ USB CDC serial from ESP32-S3 to the operator machine. **I2C from sensors to the 
 | USB cable (data-capable) | USB CDC serial to operator PC |
 | Operator PC | Serial monitor, capture, `extract_latest_packet`, `ingest_packet` |
 
+### Deployment posture
+
+Per `oesis-builds/specs/bench-air-node/v0-1.md` §F block and `../../architecture/system/deployment-maturity-ladder.md` indoor-class row:
+
+| Field | Value |
+| --- | --- |
+| Deployment class | `indoor` |
+| Power | `USB` (reverse-polarity protection from regulator) |
+| IP rating | none / IP20 acceptable |
+| Protective fixtures | none (indoor-only) |
+| Burn-in | 48 h for BME680 per `calibration-program.md` §B |
+
 ### Hardware connectivity (ASCII)
 
 ```
@@ -184,6 +196,18 @@ Three services on **loopback** on **one PC**. No USB node required for the smoke
 | AP or home router | 802.11 access; may bridge to Ethernet |
 | Ingest host | Machine running ingest API (could be same PC or another host) |
 
+### Deployment posture (varies by class)
+
+Figure 4 is protocol-generic — the same 802.11 stack covers nodes in indoor, sheltered, and outdoor-protected classes. Per-class hardware differs per `../../architecture/system/deployment-maturity-ladder.md` "Transport tier by deployment class":
+
+| Class | Power | IP rating | Protective fixture |
+| --- | --- | --- | --- |
+| Indoor (e.g., `indoor-response-node`) | USB | none / IP20 | none |
+| Sheltered (e.g., `mast-lite`) | 12V-DC or USB-from-indoor through cable gland | IP44 | **radiation shield required** per `calibration-program.md` §C item 7 (see figure 11) |
+| Outdoor-exposed (e.g., `weather-pm-mast`) | mains with outdoor-rated PSU | IP65 | radiation shield + PM airflow module |
+
+Outdoor-exposed nodes beyond Wi-Fi reach fall back to LoRa (figure 8) or cellular (figure 9).
+
 ### ASCII
 
 ```
@@ -234,6 +258,10 @@ Three services on **loopback** on **one PC**. No USB node required for the smoke
 | CPE | Customer modem/router |
 | ISP plant | Fiber, coax, or other PHY to provider |
 | Remote API | Provider datacenter (logical endpoint) |
+
+### Deployment posture
+
+Public-context feeds are a **runtime-host** concern, not a node concern. Posture inherits from the operator workstation or server environment — not governed by the deployment-maturity-ladder's node classes. Same stack is reused by Tier 2 cloud-API adapters (Ecobee, Nest, Sensibo) at capability-stage `v1.5`, which connect to provider APIs from the runtime host rather than from a sensor node. Governance: `../../architecture/system/adapter-trust-program.md` §A source-authority rules.
 
 ### ASCII
 
@@ -327,12 +355,303 @@ Policy enforcement across jobs and storage is **outside** the OSI stack.
 
 ---
 
+## 8. Deferred path: LoRa transport for outdoor nodes (v0.3+)
+
+Enters scope at program-phase `v0.3` (flood-node) and any outdoor node beyond Wi-Fi reach. Sub-GHz ISM band, long range, low throughput. Requires a LoRaWAN gateway to bridge to the ingest server.
+
+### Hardware inventory
+
+| Item | Role |
+| --- | --- |
+| Outdoor node (sensors + MCU + LoRa radio) | Emits LoRaWAN uplinks; battery+solar powered with 72h runtime floor |
+| LoRaWAN gateway | Bridges sub-GHz RF to IP backhaul |
+| Network server | LoRaWAN NS routes decoded uplinks to application servers |
+| Ingest server | Same as figure 4; receives the decoded payload |
+
+### Hardware connectivity (ASCII)
+
+```
+  +-------------------+          +---------------------+
+  | Outdoor node      |          | LoRaWAN gateway     |
+  | Sensors + MCU     |--LoRa--> | at site or nearby   |
+  | Battery + solar   |          +----------+----------+
+  +-------------------+                     |
+                                            | IP backhaul
+                                            v
+                                 +---------------------+
+                                 | LoRaWAN Network Srv |
+                                 +----------+----------+
+                                            |
+                                            v
+                                 +---------------------+
+                                 | Ingest server       |
+                                 +---------------------+
+```
+
+### OSI table (LoRaWAN + IP backhaul)
+
+| Layer | Name | Role |
+| --- | --- | --- |
+| L7 | Application | ingest API, parcel binding; JSON payload after LoRaWAN decode |
+| L6 | Presentation | LoRaWAN app-layer AES-128 (AppSKey); JSON after decode |
+| L5 | Session | LoRaWAN device session (DevAddr, session keys, frame counters) |
+| L4 | Transport | LoRaWAN MAC (Class A/B/C); UDP gateway↔network-server |
+| L3 | Network | LoRaWAN NS routing; IP for backhaul leg |
+| L2 | Data link | LoRaWAN MAC frame over LoRa PHY; Ethernet/Wi-Fi L2 on backhaul |
+| L1 | Physical | LoRa modulation at 868/915 MHz (region-dependent); antennas at node and gateway |
+
+### OSI ASCII stack
+
+```
++------------------------------------------------------------------+
+| L7  Application   | ingest API; parcel binding                   |
++------------------------------------------------------------------+
+| L6  Presentation  | LoRaWAN AES-128 app payload; JSON after       |
++------------------------------------------------------------------+
+| L5  Session       | LoRaWAN device session                        |
++------------------------------------------------------------------+
+| L4  Transport     | LoRaWAN MAC; UDP on backhaul                  |
++------------------------------------------------------------------+
+| L3  Network       | LoRaWAN NS routing; IP on backhaul            |
++------------------------------------------------------------------+
+| L2  Data link     | LoRa MAC frame; Ethernet/Wi-Fi on backhaul    |
++------------------------------------------------------------------+
+| L1  Physical      | Sub-GHz RF at 868/915 MHz                     |
++------------------------------------------------------------------+
+```
+
+---
+
+## 9. Deferred path: Cellular transport for outdoor nodes beyond Wi-Fi
+
+Enters scope when an outdoor node has no reachable Wi-Fi and no reachable LoRa gateway. Uses cellular modem (LTE Cat-M1 or NB-IoT for low power, LTE/NR for higher throughput).
+
+### Hardware inventory
+
+| Item | Role |
+| --- | --- |
+| Outdoor node with cellular modem | LTE Cat-M1, NB-IoT, or standard LTE/NR |
+| SIM / eSIM / iSIM | Operator credential |
+| Cell tower (eNodeB/gNodeB) | Operator radio access network |
+| Operator core network | PDN gateway; public-internet egress |
+| Ingest server | Over public internet; HTTPS |
+
+### Hardware connectivity (ASCII)
+
+```
+  +-------------------+          +------------------+
+  | Outdoor node      |--RF----->| Cell tower       |
+  | Sensors + MCU     |          | eNodeB / gNodeB  |
+  | + cellular modem  |          +--------+---------+
+  +-------------------+                   |
+                                          v
+                                 +------------------+
+                                 | Operator core    |
+                                 +--------+---------+
+                                          |
+                                          v
+                                 +------------------+
+                                 | Ingest server    |
+                                 | (public internet)|
+                                 +------------------+
+```
+
+### OSI table (cellular)
+
+| Layer | Name | Role |
+| --- | --- | --- |
+| L7 | Application | HTTPS ingest API as figure 4/5; identical payload shape |
+| L6 | Presentation | TLS ciphertext on wire when enabled |
+| L5 | Session | TLS session or stateless HTTP |
+| L4 | Transport | TCP to ingest listener (UDP for CoAP alternatives) |
+| L3 | Network | IP assigned by operator; operator-NATted public egress |
+| L2 | Data link | 3GPP MAC (LTE/NR); PDCP/RLC; Ethernet on core backhaul |
+| L1 | Physical | Cellular RF (band-dependent); node antenna; eNodeB/gNodeB |
+
+### OSI ASCII stack
+
+```
++------------------------------------------------------------------+
+| L7  Application   | HTTPS ingest API                             |
++------------------------------------------------------------------+
+| L6  Presentation  | TLS ciphertext                               |
++------------------------------------------------------------------+
+| L5  Session       | TLS session or stateless HTTP                |
++------------------------------------------------------------------+
+| L4  Transport     | TCP (or UDP for CoAP)                        |
++------------------------------------------------------------------+
+| L3  Network       | IP (operator-assigned; NATted egress)        |
++------------------------------------------------------------------+
+| L2  Data link     | 3GPP MAC; Ethernet on core backhaul          |
++------------------------------------------------------------------+
+| L1  Physical      | Cellular RF                                  |
++------------------------------------------------------------------+
+```
+
+Operational notes: cellular introduces operator billing, data-plan sizing, and SIM-provisioning lifecycle — product/operational concerns that gate when this path is viable for a pilot.
+
+---
+
+## 10. Deferred path: Direct-measurement adapter (circuit-monitor, v1.5)
+
+Enters scope at capability-stage `v1.5` bridge. Two chained transport legs: sensor-side (PZEM module to MCU over Modbus/RS-485) and ingest-side (MCU to server over Wi-Fi).
+
+### Hardware inventory
+
+| Item | Role |
+| --- | --- |
+| Split-core CT clamps | Non-invasive current measurement on HVAC / sump circuits |
+| PZEM-004T/016 module | Current-draw energy monitor; exposes Modbus RTU over serial |
+| MCU with Wi-Fi | Polls PZEM; re-emits `oesis.circuit-monitor.v1` JSON over Wi-Fi |
+| Electrical enclosure (IP20) | Houses the MCU + PZEM inside or adjacent to the panel |
+| Wi-Fi AP / router | Same as figure 4 |
+| Ingest server | Same as figure 4 |
+
+### Hardware connectivity (ASCII)
+
+```
+  +---------------------+
+  | Electrical panel    |
+  | CT clamps           |
+  +----------+----------+
+             | analog current
+             v
+  +---------------------+
+  | PZEM-004T / 016     |
+  +----------+----------+
+             | RS-485 or UART, Modbus RTU
+             v
+  +---------------------+     +------------------+
+  | MCU with Wi-Fi      |---->| Wi-Fi AP/router  |
+  | (electrical         |     +--------+---------+
+  |  enclosure, IP20)   |              |
+  +---------------------+              v
+                              +------------------+
+                              | Ingest server    |
+                              +------------------+
+```
+
+### OSI table — sensor-side leg (PZEM → MCU)
+
+| Layer | Name | Role |
+| --- | --- | --- |
+| L7 | Application | Modbus RTU commands and PZEM register reads |
+| L6 | Presentation | Modbus register mapping; integer and scaled-float values |
+| L5 | Session | Modbus master (MCU) polling slave (PZEM); no multi-session |
+| L4 | Transport | Modbus RTU framing over serial |
+| L3 | Network | not used; point-to-point |
+| L2 | Data link | Modbus RTU frames, CRC-16 |
+| L1 | Physical | RS-485 or UART; isolated from mains by PZEM internally |
+
+### OSI table — ingest-side leg (MCU → ingest server)
+
+Identical to figure 4 (Wi-Fi to ingest). The MCU re-emits PZEM-derived fields as an `oesis.circuit-monitor.v1` JSON packet using the same Wi-Fi stack.
+
+### Sensor-side ASCII stack
+
+```
++------------------------------------------------------------------+
+| L7  Application   | Modbus commands; PZEM register reads         |
++------------------------------------------------------------------+
+| L6  Presentation  | Modbus register map; scaled values           |
++------------------------------------------------------------------+
+| L5  Session       | Master-polls-slave                           |
++------------------------------------------------------------------+
+| L4  Transport     | Modbus RTU framing                           |
++------------------------------------------------------------------+
+| L3  Network       | not used                                     |
++------------------------------------------------------------------+
+| L2  Data link     | Modbus RTU frames, CRC-16                    |
++------------------------------------------------------------------+
+| L1  Physical      | RS-485 or UART; mains-isolated internally    |
++------------------------------------------------------------------+
+```
+
+### Tier-model note
+
+- Tier 1 passive inference (e.g., thermal-slope HVAC detection): **no on-wire path**; derives from existing sensor data.
+- Tier 2 cloud adapters (Ecobee, Nest, Sensibo): uses the HTTPS stack of figure 5.
+- Tier 3 direct-measurement adapters like circuit-monitor: figure 10 (this one); the only tier with a new physical leg.
+
+Adapter-trust-program §C admissibility rules apply to the *readings*, not to the Modbus transport — but the Modbus leg must succeed before any reading exists.
+
+---
+
+## 11. Radiation shield hardware (protective fixture for sheltered and outdoor temperature readings)
+
+Not an OSI path. The radiation shield is a **physical-layer hardware component** whose presence and verification gate temperature-reading admissibility per `../../architecture/system/calibration-program.md` §C item 7. Figure 11 captures the shield as a hardware component because prior figures (4, 8, 9) assume it implicitly without drawing it.
+
+### Hardware inventory
+
+| Item | Role |
+| --- | --- |
+| SHT45 sensor with sintered filter | Temperature + RH; the sensing element to be shielded |
+| Inner stacked cones or louvered vanes | Deflect direct and reflected solar radiation while permitting ambient airflow across sensor |
+| White outer finish (high albedo) | Reflect incident solar energy; reduce thermal absorption by shield body |
+| Mast or wall mount (below solar line where possible) | Mechanical attachment; positioned to avoid reflected heat from light-colored walls/roofs |
+| MCU cable | Carries sensor readings to the transport node per figure 4, 8, or 9 |
+
+### ASCII
+
+```
+                 (Solar radiation)
+                         |
+                         v
+             +-------------------------+
+             | White outer finish      |   <- deflects direct sun
+             +-----+--------------+----+
+                   |              |
+          (Ambient air cross-flow)
+                   |              |
+             +-----v--------------v----+
+             | Inner cones / louvers   |   <- ventilated stack
+             +-----+--------------+----+
+                   |              |
+                   +--[ SHT45 ]---+      <- sintered-filter sensor inside
+                         |
+                         |
+                 I2C cable
+                         |
+                         v
+                 [ MCU (fig 4/8/9) ]
+```
+
+### Deployment posture
+
+Per `calibration-program.md` §C item 7 and `../../architecture/system/sensor-placement-and-representativeness-guide.md` sensor variant selection principles:
+
+| Field | Value |
+| --- | --- |
+| Where required | `sheltered` and `outdoor` classes — any SHT45 placement exposed to direct or reflected solar radiation |
+| Where not required | `indoor` class (no solar loading) |
+| Variant to use | Passive stacked-cone (standard), or fan-aspirated (higher accuracy, requires power + moving parts) |
+| Acceptance test | Thermal-loading test per `specs/mast-lite/radiation-shield-thermal-loading-test.md` (to author) — residual bias under full-sun must be within spec Uncertainty Budget |
+| Admissibility consequence | `protective_fixture_verified_at: null` → readings inadmissible to calibration dataset until test passes |
+
+### Why figure 11 exists
+
+- Figures 4, 8, 9 assume sheltered/outdoor placement without drawing the shield; a reader auditing §F blocks against OSI diagrams would conclude the shield is missing — it is here instead.
+- The shield has no OSI-layer representation (pure L1 hardware, not part of any communication channel), so it does not belong as a row in an OSI stack — it belongs as its own hardware-component figure.
+- The `oesis-builds/specs/mast-lite/v0-1.md` and `specs/weather-pm-mast/v0-1.md` §F blocks declare `protective_fixtures[].name: passive radiation shield` with an `acceptance_test_ref`. Figure 11 is the architectural companion to those declarations.
+
+### Related docs
+
+- `../../architecture/system/calibration-program.md` §C item 7 — admissibility rule
+- `../../architecture/system/sensor-placement-and-representativeness-guide.md` — variant selection (sintered filter for sheltered/outdoor)
+- `../../architecture/system/deployment-maturity-ladder.md` "Enclosure IP rating tier"
+- `../../architecture/system/parts/mast-lite.md`, `parts/weather-pm-mast.md` — per-node aggregator pages
+- `oesis-builds/specs/mast-lite/v0-1.md`, `specs/weather-pm-mast/v0-1.md` — §F protective_fixtures declarations
+
+---
+
 ## Matrix mapping (same as Mermaid doc)
 
 | Matrix block | Primary text figures |
 | --- | --- |
 | Software and APIs | 2, 3, 6 |
-| Hardware and field path | 1; 4 when Wi-Fi ingest is real |
+| Hardware and field path (v0.1–v0.2) | 1; 4 when Wi-Fi ingest is real; 11 for any sheltered/outdoor SHT45 |
+| Hardware and field path (v0.3+ outdoor) | 4, 8 (LoRa), 9 (cellular) depending on node install point; 11 for shield on temperature-sensing nodes |
+| Adapter surfaces (v1.5 bridge) | 10 (direct-measurement); 5 for Tier 2 cloud APIs; Tier 1 passive inference has no OSI path |
 | Governance, rights, shared-map | 6; 5 if live external aggregates feed shared-map |
 | Release, legal, public surfaces | 7 plus public-site hosting stack |
 
@@ -342,3 +661,6 @@ Policy enforcement across jobs and storage is **outside** the OSI stack.
 - `v0.1-gap-register.md` — G3, G4
 - `hardware/bench-air-node/build-guide.md`
 - `architecture/current/reference-stack.md`
+- `architecture/system/deployment-maturity-ladder.md` "Transport tier by deployment class"
+- `architecture/system/adapter-trust-program.md` — governing policy for figure 10
+- `oesis-builds/specs/flood-node/v0-1.md`, `specs/weather-pm-mast/v0-1.md`, `specs/adapters/circuit-monitor/v0-1.md` — §F blocks for figures 8, 9, 10

--- a/release/v.0.1/v0.1-osi-diagrams.md
+++ b/release/v.0.1/v0.1-osi-diagrams.md
@@ -35,6 +35,14 @@ flowchart LR
   esp --> usb --> pc
 ```
 
+**Deployment posture** (per [`oesis-builds/specs/bench-air-node/v0-1.md`](../../../oesis-builds/specs/bench-air-node/v0-1.md) §F block and [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) indoor-class row):
+
+- Deployment class: `indoor`
+- Power: `USB` (reverse-polarity protection from regulator)
+- IP rating: none / IP20 acceptable
+- Protective fixtures: none
+- Burn-in: 48 h required for BME680 per `calibration-program.md` §B
+
 ### OSI stack (USB serial leg, host parses JSON at L7)
 
 ```mermaid
@@ -132,6 +140,14 @@ flowchart LR
   node -->|80211_WLAN| ap -->|Ethernet_or_WiFi| srv
 ```
 
+**Deployment posture note.** Figure 4 is protocol-generic — the same 802.11 stack covers nodes deployed in indoor, sheltered, and outdoor-protected classes. Per-deployment-class posture differs at the hardware level (see [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) "Transport tier by deployment class"):
+
+- **Indoor** (e.g., `indoor-response-node`): USB power / IP20 / no protective fixture.
+- **Sheltered** (e.g., `mast-lite`): 12V-DC or USB-from-indoor through cable gland / IP44 / **radiation shield required as protective fixture** per [`calibration-program.md`](../../architecture/system/calibration-program.md) §C item 7 (see figure 11).
+- **Outdoor-exposed** (e.g., `weather-pm-mast`): mains with outdoor-rated PSU / IP65 / radiation shield + PM airflow module.
+
+Outdoor-exposed nodes beyond Wi-Fi reach fall back to LoRa (figure 8) or cellular (figure 9).
+
 ### OSI stack (WLAN and onward)
 
 ```mermaid
@@ -164,6 +180,8 @@ flowchart LR
   cloud[Provider_API_endpoints]
   host -->|Ethernet_or_Wi_Fi| cpe --> isp --> cloud
 ```
+
+**Deployment posture note.** Public-context feeds are a **runtime-host** concern, not a node concern. The runtime host inherits its power / enclosure posture from the operator's workstation or server environment — not governed by the deployment-maturity-ladder's node classes. Same stack is reused by Tier 2 cloud-API adapters (Ecobee, Nest, Sensibo) at capability-stage `v1.5`, which connect to provider APIs from the runtime host rather than from a physical sensor node (see [`adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md)).
 
 ### OSI stack
 
@@ -245,18 +263,235 @@ flowchart LR
 
 ---
 
+## 8. Deferred path: LoRa transport for outdoor nodes (v0.3+ flood-node, far-outdoor nodes)
+
+Not required for v0.1 or v0.2. Enters scope at **program-phase `v0.3`** (flood-node) and any later outdoor-class node whose install point is beyond reliable Wi-Fi. Distinct radio stack from figure 4 — sub-GHz ISM band, long range, low throughput; requires a gateway to bridge to the ingest server.
+
+### Hardware (LoRaWAN topology)
+
+```mermaid
+flowchart LR
+  subgraph outNode [Outdoor_node_e_g_flood_node]
+    sens2[Sensors_ultrasonic_or_air]
+    mcu2[ESP32_or_MCU_with_LoRa_radio]
+    bat[Battery_plus_solar_with_72h_floor]
+    sens2 --> mcu2
+    bat --> mcu2
+  end
+  gw[LoRaWAN_gateway_at_site_or_nearby]
+  ns[LoRaWAN_Network_Server]
+  srv3[Ingest_server_host]
+  outNode -->|sub_GHz_LoRa_modulation| gw -->|IP_backhaul_Ethernet_or_Wi_Fi| ns --> srv3
+```
+
+**Deployment posture** (per [`oesis-builds/specs/flood-node/v0-1.md`](../../../oesis-builds/specs/flood-node/v0-1.md) §F block and [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) outdoor-class row):
+
+- Deployment class: `outdoor`
+- Power: `battery + solar` with documented 72 h runtime floor (or hardened mains where available)
+- IP rating: `IP65` — flood-node installations see standing water
+- Protective fixtures: rigid mount at documented low-point + zero-reference staff gauge per `calibration-program.md` §C item 7. Pre-verification readings inadmissible.
+- Burn-in: not required (ultrasonic sensors do not need conditioning)
+
+### OSI stack (LoRaWAN + IP backhaul)
+
+```mermaid
+flowchart TB
+  subgraph pathLora [Deferred_LoRaWAN_to_ingest]
+    direction TB
+    L7l["L7 Application: ingest API, authentication, parcel binding; payload after LoRaWAN decode"]
+    L6l["L6 Presentation: LoRaWAN app-layer encryption AES-128 (AppSKey); JSON after decode"]
+    L5l["L5 Session: LoRaWAN device session (DevAddr, session keys, frame counters)"]
+    L4l["L4 Transport: LoRaWAN MAC (Class A/B/C); UDP for gateway to network-server"]
+    L3l["L3 Network: LoRaWAN network-server routing; IP for backhaul leg"]
+    L2l["L2 Data link: LoRaWAN MAC frame over LoRa PHY; Ethernet or Wi-Fi L2 on backhaul"]
+    L1l["L1 Physical: LoRa modulation at 868/915 MHz (region-dependent); antenna at node and gateway"]
+  end
+```
+
+Power-path note: LoRa deployments depend on the node-side battery+solar posture declared in the node's §F block (`power.source: battery_solar` for flood-node v0-1 skeleton) and the documented 72 h runtime floor per [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) outdoor-class row.
+
+---
+
+## 9. Deferred path: Cellular transport for outdoor nodes beyond Wi-Fi reach
+
+Not required for v0.1 / v0.2 / v0.3. Enters scope when an outdoor-class node (typically `weather-pm-mast` or a flood-node at a remote low-point) has no reachable Wi-Fi **and** no reachable LoRa gateway. Per [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) outdoor-class transport tier, cellular is permitted as a fallback for parcels beyond Wi-Fi reach.
+
+### Hardware (cellular topology)
+
+```mermaid
+flowchart LR
+  subgraph cellNode [Outdoor_node_with_cellular_modem]
+    sens3[Sensors]
+    mcu3[MCU_plus_cellular_modem_e_g_LTE_Cat_M1_NB_IoT]
+    sim[SIM_eSIM_or_iSIM]
+    mcu3 <--> sim
+    sens3 --> mcu3
+  end
+  enb[Cell_tower_eNodeB_or_gNodeB]
+  core[Mobile_operator_core_network]
+  srv4[Ingest_server_over_public_internet]
+  cellNode -->|RF_to_tower| enb --> core --> srv4
+```
+
+**Deployment posture** (per [`oesis-builds/specs/weather-pm-mast/v0-1.md`](../../../oesis-builds/specs/weather-pm-mast/v0-1.md) §F block pattern and [`deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) outdoor-class row):
+
+- Deployment class: `outdoor` (typically weather-pm-mast or flood-node beyond Wi-Fi reach)
+- Power: mains with outdoor-rated PSU (preferred for weather-pm-mast due to active PM-sensor flow path) or battery + solar (for flood-node)
+- IP rating: `IP65`
+- Protective fixtures: radiation shield + PM airflow module for weather-pm-mast (see figure 11 for shield); rigid mount + zero-reference for flood-node
+- Burn-in: 48 h for BME680 + PM-sensor conditioning per `calibration-program.md` §B
+
+### OSI stack (cellular)
+
+```mermaid
+flowchart TB
+  subgraph pathCell [Deferred_cellular_to_ingest]
+    direction TB
+    L7c["L7 Application: HTTPS ingest API as figure 4 / 5; identical payload shape"]
+    L6c["L6 Presentation: TLS ciphertext on wire when enabled"]
+    L5c["L5 Session: TLS session or stateless HTTP"]
+    L4c["L4 Transport: TCP to ingest listener (UDP for CoAP alternatives)"]
+    L3c["L3 Network: IP assigned by operator; operator-NATted public egress"]
+    L2c["L2 Data link: 3GPP MAC (LTE / NR); PDCP/RLC; Ethernet on core backhaul"]
+    L1c["L1 Physical: cellular RF (band-dependent); antenna at node, eNodeB/gNodeB at tower"]
+  end
+```
+
+Operational notes: cellular introduces operator billing, data-plan sizing, and SIM-provisioning lifecycle concerns that Wi-Fi (figure 4) and LoRa (figure 8) do not. These are product/operational concerns, not OSI concerns, but they gate when this path is viable for a pilot. Power-path: similar to LoRa — outdoor-class power tier required per §F.
+
+---
+
+## 10. Deferred path: Direct-measurement adapter (circuit-monitor, v1.5)
+
+Not required for v0.1 / v0.2 / v0.3 / v0.5 / v1.0. Enters scope at **capability-stage `v1.5`** bridge when `circuit-monitor` (Tier 3 direct-measurement adapter per [`adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md)) ships. Unlike Wi-Fi (figure 4) or LoRa (figure 8), this path has **two chained transport legs**: a sensor-side leg from PZEM-004T/016 to the MCU, and an ingest-side leg from the MCU to the ingest server. OSI applies to both legs at different points.
+
+### Hardware (chained transport)
+
+```mermaid
+flowchart LR
+  subgraph panel [Electrical_panel]
+    ct[CT_clamp_split_core]
+    pzem[PZEM_004T_or_016_module]
+    ct -->|analog_current| pzem
+  end
+  subgraph enclosure [Electrical_enclosure_IP20]
+    mcu4[MCU_with_Wi_Fi]
+    pzem -->|RS_485_or_UART_serial_Modbus| mcu4
+  end
+  ap2[Wi_Fi_AP_or_router]
+  srv5[Ingest_server]
+  mcu4 -->|802_11_WLAN| ap2 --> srv5
+```
+
+**Deployment posture** (per [`oesis-builds/specs/adapters/circuit-monitor/v0-1.md`](../../../oesis-builds/specs/adapters/circuit-monitor/v0-1.md) §F block — **adapter** (adapter-trust-program §F) with physical_posture declared):
+
+- Tier: `tier_3_direct` per adapter-trust-program
+- Physical deployment class: `indoor` (mains-adjacent; inside or near electrical panel)
+- Power: low-power from the measured circuit (the module takes power from the circuit it measures)
+- IP rating: electrical-enclosure IP20
+- Protective fixture: electrical-code-compliant CT clamp installation — hard prerequisite, licensed electrician required in many jurisdictions
+- Burn-in: not required (Modbus module is factory-calibrated)
+
+### OSI stack (two legs)
+
+**Sensor-side leg (PZEM → MCU):**
+
+```mermaid
+flowchart TB
+  subgraph pathPzem [Sensor_leg_PZEM_to_MCU]
+    direction TB
+    L7pz["L7 Application: Modbus RTU commands and PZEM register reads"]
+    L6pz["L6 Presentation: Modbus register mapping; integer and scaled-float values"]
+    L5pz["L5 Session: Modbus master (MCU) polling the slave (PZEM); no multi-session"]
+    L4pz["L4 Transport: Modbus RTU framing over serial"]
+    L3pz["L3 Network: not used; point-to-point"]
+    L2pz["L2 Data link: Modbus RTU frames, CRC-16"]
+    L1pz["L1 Physical: RS-485 or UART; isolated from mains by the PZEM module internally"]
+  end
+```
+
+**Ingest-side leg (MCU → ingest server):**
+
+Identical to figure 4 (Wi-Fi to ingest). The MCU re-emits PZEM-derived fields as an `oesis.circuit-monitor.v1` JSON packet and uses the same Wi-Fi stack.
+
+### Why this figure exists
+
+The sensor-side leg is **distinct** from figures 1–4 because the PZEM module sits on a mains-adjacent circuit with its own isolation requirements, Modbus protocol, and electrical-code compliance story (see the §F `physical_posture.protective_fixtures` block in `oesis-builds/specs/adapters/circuit-monitor/v0-1.md`). Drawing the whole path as "just Wi-Fi to ingest" would miss the Modbus transport and the installation-code-compliance gate. Adapter-trust-program §C admissibility rules apply to the *readings*, not to the Modbus transport — but the Modbus leg must succeed before any reading exists.
+
+Tier-model note: Tier 1 passive inference (e.g., thermal-slope HVAC detection) has **no on-wire path** — it derives from existing sensor data. Tier 2 cloud adapters (Ecobee, Nest) use the HTTPS stack of figure 5. Tier 3 direct-measurement adapters like circuit-monitor are the only tier with a new physical leg, hence this figure.
+
+---
+
+## 11. Radiation shield hardware (protective fixture for sheltered and outdoor temperature readings)
+
+Not an OSI path. The radiation shield is a **physical-layer hardware component** whose presence and verification gate temperature-reading admissibility per [`calibration-program.md`](../../architecture/system/calibration-program.md) §C item 7. Figure 11 captures the shield as a hardware component because prior figures (4, 8, 9) assume it implicitly without drawing it, and its acceptance test is a prerequisite for outdoor-class sensor data.
+
+### Hardware block
+
+```mermaid
+flowchart TB
+  subgraph shield [Passive_or_fan_aspirated_radiation_shield]
+    sht4[SHT45_sensor_with_sintered_filter]
+    shellInner[Inner_stacked_cones_or_louvered_vanes]
+    shellOuter[White_outer_finish_high_albedo]
+    sht4 -.sheltered_by.-> shellInner
+    shellInner -.enclosed_by.-> shellOuter
+  end
+  mount[Mast_or_wall_mount_below_solar_line]
+  esp5[MCU_with_transport_per_figure_4_8_or_9]
+  shield --> mount
+  sht4 -->|I2C_cable| esp5
+  sun((Solar_radiation))
+  air((Ambient_air_cross_flow))
+  sun -.deflected_by.-> shellOuter
+  air -.flows_through.-> shellInner
+```
+
+### What the shield does and why it is in this doc
+
+- **Reduces solar-loading bias** on temperature readings. Bare SHT45 outdoors under direct sun can read 2–4 °C high. The shield deflects direct and reflected solar radiation while allowing ambient-air cross-flow across the sensor.
+- **Without a verified shield, temperature readings from the SHT45 are inadmissible** to the calibration dataset used for hazard-formula coefficient fitting per `calibration-program.md` §C item 7.
+- The shield is a **protective fixture** in the §F block of every node spec that deploys SHT45 in sheltered or outdoor class — `mast-lite`, `weather-pm-mast`. Per-node spec declares variant (passive / fan-aspirated) and cites the thermal-loading acceptance test.
+
+### Acceptance test (to author per `oesis-builds/specs/mast-lite/radiation-shield-thermal-loading-test.md`)
+
+Thermal-loading test compares SHT45-inside-shield readings to a shaded characterized reference over a daily solar cycle. Acceptance criterion: residual bias under full-sun exposure is within the spec's Uncertainty Budget. Pre-verification readings from the shielded SHT45 are tagged `protective_fixture_verified_at: null` and excluded from the calibration dataset until the test passes.
+
+### Relationship to OSI figures
+
+The shield has no OSI-layer representation — it is pure L1 hardware, and it is not part of any communication channel. It appears in this doc because:
+
+- Figures 4, 8, and 9 assume sheltered or outdoor placement without drawing the shield.
+- The `oesis-builds/specs/mast-lite/v0-1.md` and `specs/weather-pm-mast/v0-1.md` §F blocks declare the shield as a protective fixture, which has admissibility consequences.
+- A reader auditing "is everything in the §F block represented in the OSI diagrams?" should not conclude the shield is missing — it is here.
+
+Related docs:
+
+- [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §C item 7 — admissibility rule
+- [`../../architecture/system/sensor-placement-and-representativeness-guide.md`](../../architecture/system/sensor-placement-and-representativeness-guide.md) — sensor variant selection (sintered filter required for sheltered and outdoor classes)
+- [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) "Enclosure IP rating tier" — sheltered and outdoor enclosure requirements
+- [`../../architecture/system/parts/mast-lite.md`](../../architecture/system/parts/mast-lite.md) and [`parts/weather-pm-mast.md`](../../architecture/system/parts/weather-pm-mast.md)
+
+---
+
 ## How this maps to the implementation status matrix
 
 | Matrix block | Primary OSI figures |
 | --- | --- |
 | Software and APIs | 2, 3, 6 when HTTP admin or shared-map is used |
-| Hardware and field path | 1; figure 4 when Wi-Fi ingest is real |
+| Hardware and field path (v0.1–v0.2) | 1; figure 4 when Wi-Fi ingest is real; figure 11 for any sheltered/outdoor SHT45 |
+| Hardware and field path (v0.3+ outdoor) | 4, 8 (LoRa), 9 (cellular) depending on node install point; 11 for shield on temperature-sensing nodes |
+| Adapter surfaces (v1.5 bridge) | 10 (direct-measurement, circuit-monitor); 5 for Tier 2 cloud APIs; Tier 1 passive inference has no OSI path |
 | Governance, rights, shared-map | 6; figure 5 if live external aggregates feed shared-map |
 | Release, legal, public surfaces | 7 plus the stack that hosts the public site (outside v0.1 runtime) |
 
 ## Related
 
-- `v0.1-osi-diagrams-text.md` — same seven figures as tables and ASCII stacks (with hardware sections)
+- `v0.1-osi-diagrams-text.md` — same ten figures as tables and ASCII stacks (with hardware sections)
 - `architecture/current/reference-stack.md` — logical pipeline (non-OSI flowchart)
+- `architecture/system/deployment-maturity-ladder.md` "Transport tier by deployment class" — canonical source for when each transport path is permitted per class
+- `architecture/system/adapter-trust-program.md` — governing policy for figure 10's circuit-monitor adapter
 - `v0.1-gap-register.md` — G3 and G4 illustrated in figures 4 and 5
+- `oesis-builds/specs/flood-node/v0-1.md` and `specs/weather-pm-mast/v0-1.md` — §F blocks declaring when LoRa / cellular transports are permitted per node
+- `oesis-builds/specs/adapters/circuit-monitor/v0-1.md` — §F block for figure 10
 - `hardware/bench-air-node/build-guide.md` — BOM and wiring for figure 1

--- a/release/v1.0/v1.0-launch-checklist.md
+++ b/release/v1.0/v1.0-launch-checklist.md
@@ -84,6 +84,11 @@ Each gate includes the tier it applies to, current status, and the evidence need
 | HR-4 | Integrated parcel-kit BOM understandable by non-author | Both | In progress | Procurement checklist exists; named vendor/SKU decisions outstanding |
 | HR-5 | Named BOM vendor decisions for Tier 2 kit | Tier B | Not started | At least one complete Tier 2 purchase path with named sources |
 | HR-6 | Flood-node install validated (if in scope for pilot parcel) | Tier B | Not started | Low-point install record, rigid geometry, marker discipline |
+| HR-7 | Every deployed node has a §F build-spec metadata block | Both | In progress | `oesis-builds/specs/<node>/v0-X.md` front-matter per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §F (bench-air applied 2026-04-19; 5 others have skeleton blocks). Closes G16. |
+| HR-8 | At least one characterized reference instrument populated per measurand per deployment class | Tier B | Not started | File under `oesis-builds/procedures/<node>/references/<slug>.md` satisfying calibration-program §A minimum-fields schema. Placeholder `references/TBD.md` not acceptable. Closes G13. |
+| HR-9 | BME680 burn-in gate enforced in bring-up acceptance | Both | In progress | 48 h window before `burn_in_complete: true`. Bring-up procedure updated 2026-04-19 at procedure level; full enforcement requires ingest-side flag. Closes G14 in part. |
+| HR-10 | Protective-fixture acceptance tests passed for outdoor-class nodes | Tier B | Not started | Radiation-shield thermal-loading (mast-lite, weather-pm-mast) and rigid-mount + zero-reference (flood-node) per calibration-program §C item 7. |
+| HR-11 | Admissibility tooling active on ingest | Tier B | Not started | `admissible_to_calibration_dataset` + reason codes emitted on each normalized observation. Schema extensions in `oesis-contracts` (G17) + runtime wiring (G15). |
 
 ## Release copy gates
 

--- a/release/v1.0/v1.0-pilot-minimum-subset.md
+++ b/release/v1.0/v1.0-pilot-minimum-subset.md
@@ -47,6 +47,11 @@ Before any real participant, household, or identifiable parcel data, treat these
 | Installation metadata capture for trust scoring | Product gates (PU-5) |
 | Deployment-quality flags visible in parcel view | Product gates (PU-6) |
 | Claims and safety language reviewed for participant-facing materials | Governance gates (GL-3), Release gates (RC-5) |
+| Every deployed node has a §F build-spec metadata block | Hardware gates (HR-7) |
+| At least one characterized reference instrument populated per measurand per class | Hardware gates (HR-8) |
+| BME680 burn-in gate enforced in bring-up acceptance | Hardware gates (HR-9) |
+| Protective-fixture acceptance tests passed for outdoor-class nodes | Hardware gates (HR-10) |
+| Admissibility tooling active on ingest | Hardware gates (HR-11) |
 
 ## Explicit non-requirements: Tier A
 

--- a/release/v1.0/v1.0-scope-matrix.md
+++ b/release/v1.0/v1.0-scope-matrix.md
@@ -56,6 +56,23 @@ This matrix complements `v1.0-scope.md` (single-source release boundary) with a 
 | Public parcel-resolution map | No | Deferred | Explicit red line | Parcel-private evidence must never become parcel-resolution public output. |
 | Sharing controls and hard boundary enforcement | Yes | Docs-only | Sharing store schema, sharing settings schema | Product surfaces must match policy claims before public sharing surface. |
 
+## Calibration-program and adapter-trust-program posture
+
+Per the 5-item promotion bar in [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md) item 5, every node family in v1.0 scope must meet **`deployment maturity v1.0` calibration posture** per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §G. Adapters (none in core v1.0 scope; relevant at v1.5) follow [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §G.
+
+| Compliance surface | v1.0 status | Gap register |
+|---|---|---|
+| §F build-spec metadata block per node | Partial — bench-air §F applied 2026-04-19; mast-lite, flood-node, weather-pm-mast, thermal-pod, circuit-monitor have skeleton §F blocks pending BOM/procedures | G12, G16 |
+| §A reference instruments populated | **Open** — `references/TBD.md` placeholder only; no characterized reference on file | G13 |
+| §B burn-in gate in bring-up acceptance | Partial — bench-air bring-up procedure updated 2026-04-19; full enforcement needs ingest-side `burn_in_complete` flag | G14 |
+| §C admissibility rule in ingest | **Open** — policy defined; runtime wiring not shipped | G15 |
+| Observation-schema facts in oesis-contracts | **Open** — schema extensions planned for v1.0 lane | G17 |
+| §G tier-appropriate compliance per node | Partial — bench-air targets v1.0; mast-lite + flood-node target v1.0; weather-pm-mast targets v1.5; thermal-pod deliberately held below v1.0 | G12 |
+
+**Tier A (internal reference) posture.** Calibration compliance is recommended but not gating. v1.0 Tier A can sign off with calibration-program at docs-only status if acceptance commands pass and the admissibility-unknown caveat is accepted.
+
+**Tier B (external pilot) posture.** Calibration compliance is a **hard stop-ship gate** per gap G19. See [`v1.0-pilot-minimum-subset.md`](v1.0-pilot-minimum-subset.md) and [`../../operations/pilots/first-block-pilot.md`](../../operations/pilots/first-block-pilot.md) "Calibration-program compliance" section.
+
 ## Explicit non-goals for v1.0
 
 The following are intentionally outside v1.0 scope. They belong to later capability stages (v1.5, v2, or beyond) as defined in the phase roadmap.

--- a/release/v1.0/v1.0-scope.md
+++ b/release/v1.0/v1.0-scope.md
@@ -53,6 +53,20 @@ As of 2026-04-15, all v1.0 Tier A (internal pilot) software blockers are resolve
 
 **Tier B (external pilot) gaps remain open:** ingest authorization, Wi-Fi transport, live public feeds, installation metadata UI, mast-lite field hardening, named BOM vendors, claims/safety review.
 
+## Deployment maturity at v1.0
+
+Per the 5-item promotion bar in [`../../architecture/current/pre-1.0-version-progression.md`](../../architecture/current/pre-1.0-version-progression.md), every node family shipped as part of this v1.0 packet must meet **deployment-maturity `v1.0`** calibration posture per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §G:
+
+- **§F build-spec metadata block** present on every node's `oesis-builds/specs/<node>/v0-X.md`, declaring deployment class, deployment-maturity target, measurands with sensor variants and accuracy statements, reference instruments, burn-in configuration, protective fixtures, transport, and power source.
+- **§A reference instruments** populated — at least one characterized reference per measurand per deployment class under `oesis-builds/procedures/<node>/references/`.
+- **§B burn-in gate** enforced in bring-up acceptance for BME680 / BME688 bearing nodes (48 h platform default).
+- **§C admissibility rule** active on ingest — `admissible_to_calibration_dataset` + reason codes emitted on each normalized observation.
+- **§E calibration session logs** on record for every deployed unit.
+
+Cross-reference: class / power tier / IP tier / transport tier defaults per deployment class live in [`../../architecture/system/deployment-maturity-ladder.md`](../../architecture/system/deployment-maturity-ladder.md) "Deployment-class standards". Hardware role map with per-node posture summary lives in [`../../architecture/system/integrated-parcel-system-spec.md`](../../architecture/system/integrated-parcel-system-spec.md) "Deployment posture per node".
+
+**Current posture** (as of this packet cut): calibration-program and adapter-trust-program are `docs-only`; §F blocks are `planned` (G13–G18 tracked in [`../v.0.1/v0.1-gap-register.md`](../v.0.1/v0.1-gap-register.md)). This v1.0 release packet documents the target posture; execution across `oesis-builds/` happens in the program-phase `v0.2` / Milestone 2 promotion window.
+
 ## Explicit non-goals for this packet cut
 
 - Claiming **full** PRD current-v1 consumer experience (app store, notifications, timeline).

--- a/software/inference-engine/architecture.md
+++ b/software/inference-engine/architecture.md
@@ -80,6 +80,16 @@ computation:
 - versioned divergence-threshold configuration
 - policy constraints on whether shared neighborhood evidence is allowed for the parcel's active sharing mode
 
+### Planned: admissibility filter on normalized observations
+
+Per ADR [0009](../../meta/adr/0009-admissibility-schema-split-facts-vs-decision.md) and [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §C, the inference engine consumes the `admissible_to_calibration_dataset: bool` + `admissibility_reasons: [string]` fields that ingest attaches to each normalized observation.
+
+- **Coefficient fitting** (when the v1 hazard formula's shadow path is active per [`hazard-formula-v1.md`](hazard-formula-v1.md)): admits **only** observations where `admissible_to_calibration_dataset: true`. Non-admissible observations remain in audit logs but do not train coefficients.
+- **Parcel-state computation**: may consume non-admissible observations but with reduced confidence and with `admissibility_reasons` surfaced in the explanation payload.
+- **Branch by tier**: observations with `adapter_tier: tier_1_passive` or `tier_2_adapter` are evaluated under [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §C rather than calibration-program §C. The same `admissible_to_calibration_dataset` output is produced; only the rule set differs.
+
+Status: **planned**. Schema extensions tracked as G17; runtime wiring tracked as G15.
+
 ## Outputs
 
 - parcel-state snapshots

--- a/software/inference-engine/hazard-formula-v1-phase1.md
+++ b/software/inference-engine/hazard-formula-v1-phase1.md
@@ -1,0 +1,257 @@
+# Hazard Formula v1 — Phase 1 Preparation
+
+## Purpose
+
+Operational prerequisites that must land before v1 coefficient fitting can start. This doc turns the plan in `hazard-formula-v1.md` into four concrete artifacts:
+
+1. Calibration dataset schema for pilot incident logs.
+2. Pilot-log readiness checklist — runnable as a validation pass over existing logs.
+3. Gas-resistance rolling-baseline prototype algorithm and replay harness.
+4. NWS HeatRisk reference data approach, including a correction to the v1 heat sensor term.
+
+Scope is program-phase `v0.2` / Milestone 2 (capability stage `current v1`) per `../../architecture/current/milestone-roadmap.md`. Not required for v0.1 sign-off.
+
+## Status
+
+Draft, 2026-04-19.
+
+## Phase 0 — Hardware prerequisites (blocking)
+
+The statistical work in sections 1–4 assumes sensor data trustworthy enough to calibrate coefficients against. A hardware-readiness audit on 2026-04-19 found three blockers that must be resolved before coefficient fitting can begin. Attempting to fit coefficients before these are in place would encode bring-up drift, un-referenced readings, and missing hardware lanes into the "evidence-based" formula — the exact failure mode the v1 sensor-primacy contract is meant to prevent.
+
+**Policy home.** P0.1 and P0.2 below operationalize requirements that now live at platform level in [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md). That doc is the single source of truth for reference-instrument standards, burn-in policy, and admissibility of readings to the calibration dataset. The Phase 0 items here are the hazard-formula-side view of the same contract.
+
+### P0.1 — Characterized reference instrument
+
+**Blocker.** [`oesis-builds/procedures/bench-air-node/calibration.md`](../../../oesis-builds/procedures/bench-air-node/calibration.md) requires a characterized reference instrument for every calibration session, but `references/TBD.md` is a placeholder. No unit has been calibrated against a real referent. Coefficient fitting against this data would be statistically precise but physically meaningless.
+
+Done when: at least one reference instrument file exists per measurand per deployment class under [`oesis-builds/procedures/<node>/references/`](https://github.com/lumenaut-llc/oesis-builds/tree/main/procedures), matching the file format and minimum fields specified in [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §A.
+
+### P0.2 — Burn-in gate enforced in bring-up acceptance
+
+**Blocker for gas-resistance term only.** BME680 gas resistance needs 24–48 h conditioning on first power-up before the baseline is physically stable. [`oesis-builds/specs/bench-air-node/v0-1.md:211`](../../../oesis-builds/specs/bench-air-node/v0-1.md:211) currently checks "trending gradually," which is a posture observation, not a gate. The first 48 h of every device's data must be excluded from the calibration dataset, or the rolling baseline fits will encode conditioning artifacts.
+
+Done when: bring-up acceptance includes an explicit 48 h burn-in window per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §B, and the ingest pipeline tags observations as `burn_in_complete: false` until that window has passed for each device. Admissibility rule in calibration-program §C then excludes pre-burn-in readings automatically.
+
+### P0.3 — Mast-lite build spec (decision: option A, 2026-04-19)
+
+**Blocker for heat primary path.** The canonical heat sensor term in [`hazard-formula-v1.md`](hazard-formula-v1.md) assumes an outdoor temperature source. Bench-air-node is documented as indoor-only ([`oesis-builds/specs/bench-air-node/v0-1.md:26`](../../../oesis-builds/specs/bench-air-node/v0-1.md:26)). Mast-lite is referenced in architecture and milestone docs but has no build spec, no calibration procedure, no BOM, no radiation-shield specification in `oesis-builds/`. The formula is ahead of the hardware.
+
+**Decision (2026-04-19):** write the spec (option A). The alternative — scoping heat to bridge-path-only — was rejected because the indoor-bridge path cannot physically represent parcel-wide outdoor heat, which is the claim the parcel-state output needs to support.
+
+Done when:
+- `oesis-builds/specs/mast-lite/v0-1.md` exists with BOM, wiring, firmware pin-out, and a reproducible build procedure.
+- `oesis-builds/procedures/mast-lite/calibration.md` exists, citing at least one characterized reference instrument (may reuse the bench-air reference from P0.1, or add a distinct outdoor-suitable referent).
+- Radiation-shield design is documented inside the build spec, with a thermal-loading acceptance test. Readings from a unit without a verified shield are not admissible into the calibration dataset.
+- Build has been independently reproduced at least once (per Milestone 2 acceptance).
+
+Tracked in gap register as G12. Milestone 2 acceptance criteria updated to reflect the spec requirements as gate items.
+
+### P0 → P1 ordering
+
+Sections 1–4 are all valid work items, but they build on P0:
+
+- Section 1 (calibration dataset schema) can be drafted without P0, but the first dataset version that admits records cannot be cut until P0.1 and P0.2 are resolved.
+- Section 2 (readiness checklist) should add P0.1 and P0.2 as additional pass criteria before the checklist is run.
+- Section 3 (rolling-baseline replay) can prototype against any trace but cannot promote its parameters out of `research/` until P0.1 gives a referent for "good."
+- Section 4 (HeatRisk approach) is purely informational until P0.3 is resolved; the primary heat path can't be exercised otherwise.
+
+## Section 1 — Calibration dataset schema
+
+### Record format
+
+Each record is one labeled hazard window at one parcel. Storage: JSONL, one record per line. Canonical field set:
+
+```json
+{
+  "record_id": "<uuid>",
+  "parcel_id": "<string>",
+  "hazard": "smoke | heat",
+  "window_start": "<ISO 8601 UTC>",
+  "window_end": "<ISO 8601 UTC>",
+  "label": "present | absent | uncertain",
+  "label_source": "operator_field_report | public_advisory | dispatch_record | sensor_corroboration | self_report",
+  "label_confidence": "high | medium | low",
+  "labeler_id": "<string>",
+  "labeled_at": "<ISO 8601 UTC>",
+  "parcel_context_snapshot_ref": "<path or hash of parcel_context at window_start>",
+  "sensor_trace_ref": "<path or hash of raw packet trace covering window_start - 72h to window_end + 1h>",
+  "public_context_snapshot_ref": "<optional path or hash>",
+  "notes": "<freeform, short>"
+}
+```
+
+Field rules:
+
+- `window_start` / `window_end` are the **event** window, not the alert window. If labeled from a public advisory, use the advisory's effective period, not the time the operator read it.
+- `parcel_context_snapshot_ref` must reference a snapshot taken at or before `window_start`. Pulling "current" parcel context when labeling a past event introduces data leakage — fit coefficients would encode today's parcel, not the parcel at event time.
+- `sensor_trace_ref` must cover at least 72 h of pre-window history so rolling-baseline terms can be computed without truncation.
+- `label` of `uncertain` keeps the record for EDA and negative-class sampling analysis but is excluded from coefficient fitting.
+
+### Label source hierarchy
+
+Preferred order when multiple sources exist for the same window, highest trust first:
+
+1. `dispatch_record` — fire department / EMS record naming the parcel or immediate vicinity.
+2. `public_advisory` — NWS, AirNow, or equivalent active during the window and covering the parcel.
+3. `operator_field_report` — signed operator observation with contemporaneous notes.
+4. `sensor_corroboration` — multi-source sensor agreement (mast-lite + bench-air + public AQI) only when no human/agency source exists. Marked `label_confidence: low`.
+5. `self_report` — parcel occupant, marked `low` unless corroborated.
+
+Label source is **not** the same as sensor trace. Using the bench-air sensor itself as the label for its own prediction creates a circular fit; `sensor_corroboration` must use sources the model does not train on.
+
+### Negative-class sampling
+
+Coefficient fits require negative examples (hazard absent). Three sampling strategies, pick per hazard and document per dataset:
+
+- **Random windows** — uniformly sampled from non-event parcel-time. Cheap but class imbalance hurts calibration.
+- **Matched parcels** — for each positive, sample one negative from a similar parcel during a period with no public advisories and no dispatch records. Better calibration; requires parcel-similarity metric (initial: same climate zone + same smoke-exposure class).
+- **Stratified by season / time-of-day** — avoids seasonal confounding (e.g., summer positives vs. winter negatives).
+
+Every calibration dataset version must record the negative-sampling method in its manifest.
+
+## Section 2 — Pilot-log readiness checklist
+
+Run this pass against the existing pilot logs before fitting any v1 coefficient. Each check below should be expressible as a query or script against the log store; report pass/fail + counts per hazard.
+
+| # | Check | Pass criterion | Failure mode | Remediation |
+|---|---|---|---|---|
+| R1 | Labels are outcomes, not prior predictions | Every labeled record has a `label_source` from the hierarchy in §1, and none list the system's own alert as the source | Circular training — model learns to reproduce v0 alerts rather than real events | Relabel from independent source, or exclude from fitting |
+| R2 | Label timestamps are event windows, not alert windows | `window_start` / `window_end` match the hazard's occurrence, verifiable against at least one outside source for a sample | Temporal leak; sensor terms evaluated at wrong time | Recompute windows; prefer dispatch or advisory timestamps |
+| R3 | Parcel context snapshotted at event time | Every record's `parcel_context_snapshot_ref` exists and predates `window_start`; no "current state" backfill | Priors encode post-event state (e.g., roof replaced after fire) | Rebuild snapshots from historical parcel-context versioned store, or drop records with missing snapshots |
+| R4 | Sensor traces include ≥ 72 h preceding baseline window | Every record's trace covers `window_start - 72h` continuously; gaps logged | Rolling baseline term truncates, inflating z-score noise | Pad window from trace store, or exclude; document exclusion rate |
+| R5 | Negative-class sampling documented | Manifest names the sampling method; ratio of positives:negatives recorded per hazard | Class imbalance silently shifts calibration | Resample with documented strategy before fitting |
+
+Minimum pass threshold: R1, R3, R5 must pass 100 %. R2 and R4 may pass with documented exclusion rate ≤ 15 %; records that fail drop from the fitting set.
+
+Report format — one row per check, per hazard:
+
+```
+R1 smoke  PASS  n_records=42  n_dropped=0   note="all labels from dispatch or advisory"
+R1 heat   FAIL  n_records=28  n_dropped=11  note="11 records list v0 alert as label source; exclude"
+R2 smoke  PASS  ...
+```
+
+## Section 3 — Gas-resistance rolling-baseline prototype
+
+### Algorithm
+
+Per device, per observation:
+
+1. Maintain a sliding window `W_base` of recent gas-resistance readings, default **48 h**.
+2. Exclude the most recent `W_exclude` window, default **30 min**, to prevent active events from contaminating the baseline.
+3. Compute:
+   - `median_base = median(readings in [t - W_base, t - W_exclude])`
+   - `mad_base = median(|reading - median_base|)`
+   - `sigma_base_robust = 1.4826 * mad_base` (equivalent to stdev under Gaussian assumption)
+4. Signal:
+   - `z_gas(t) = -(R(t) - median_base) / max(sigma_base_robust, sigma_floor)`
+   - Negated so **drops** in gas resistance (consistent with VOC/smoke loading) produce **positive** z.
+5. Saturate: `z_gas(t) = clamp(z_gas(t), -3.0, +8.0)`.
+6. Emit a **baseline-stability flag**: `unstable` if `sigma_base_robust > sigma_unstable_ceiling` or `n_readings_in_window < n_min`.
+
+### Default parameters (all must carry provenance when promoted)
+
+| Parameter | Default | Rationale for default | Tuning source |
+|---|---|---|---|
+| `W_base` | 48 h | Long enough to smooth diurnal variation; short enough to adapt to device conditioning | Tune via replay — see validation below |
+| `W_exclude` | 30 min | Matches typical smoke event rise time from bench tests | Refine against pilot events |
+| `sigma_floor` | device-specific, init 1000 Ω | Prevents divide-by-near-zero on very stable devices | Per-device fit |
+| `n_min` | 180 readings (≈ 1 h of 20 s samples) | Below this, dispersion estimate is too noisy | Sensitivity analysis |
+| `sigma_unstable_ceiling` | 10× median(sigma_base) across fleet | Flags devices still conditioning or contaminated | Fleet statistics |
+
+### Replay harness
+
+Purpose: compare v0 fixed-ohm bands vs v1 rolling-baseline z on the **same** sensor traces and labels, report signal-to-noise and precision-recall curves.
+
+Inputs:
+
+- sensor trace JSONL per device (bench-air packet stream)
+- calibration dataset from §1
+- v0 config (`hazard_thresholds_v0.json`, smoke gas-resistance bands)
+- v1 parameter set from table above
+
+Outputs (one set per hazard):
+
+- PR curve for v0 score vs labels
+- PR curve for v1 z_gas vs labels
+- Brier score for each score converted to probability
+- Reliability diagram (10-bin)
+- Per-device baseline stability distribution
+- Event-wise signal-to-noise: mean z_gas during labeled positive windows vs mean during negatives
+
+Promotion bar: v1 must beat v0 on **both** Brier and area-under-PR, on the same dataset, for smoke. No promotion on heat from this prototype alone — heat needs the HeatRisk reference data in §4.
+
+Suggested module layout (paper design, not implementation):
+
+```
+oesis-runtime/research/
+  rolling_baseline/
+    baseline.py              # the algorithm above as a pure function
+    replay.py                # load traces + labels, run baseline, produce PR / Brier
+    config.py                # parameter set, versioned
+    reports/                 # replay outputs land here, named by config version
+```
+
+Kept under `research/` not `oesis/inference/v1_1/` because it's a prototype. Promotion to `v1_1/` happens only after the replay beats v0 and the parameters are provenance-tagged.
+
+## Section 4 — NWS HeatRisk reference data approach
+
+### Canonical heat sensor term
+
+The canonical heat sensor term is defined in [`hazard-formula-v1.md`](hazard-formula-v1.md) under "Heat: S_heat(t)". That doc is the single source of truth for the formula.
+
+Summary for context here: $S_{\text{heat}}$ is a combined day/night z-score against per-parcel, per-date local climatology (not a fixed onset temperature), computed from NOAA NCEI 30-year daily Climate Normals preloaded per parcel at onboarding.
+
+The correction happened on 2026-04-19 because the initial v1 draft treated HeatRisk's "category-1 onset" as a fixed per-zone temperature. NWS HeatRisk methodology is percentile-based per grid cell and per date, and uses both daily max and daily min. This doc captures the access paths and fallback logic that support the corrected formula.
+
+### Access paths (ranked by directness)
+
+| Option | What it gives | Latency | Engineering cost |
+|---|---|---|---|
+| NWS HeatRisk gridded product via the HeatRisk public page and experimental data service | Current HeatRisk category and sub-category value per grid cell | Real-time forecast | Low read, medium parse (images + data layers; confirm terms before programmatic pull) |
+| NOAA NDFD (National Digital Forecast Database) GRIB2 grids | Raw forecast temperatures; HeatRisk can be recomputed | Real-time | Medium (GRIB tooling) |
+| NOAA NCEI Climate Normals — 30 y daily normals at 1 km grid | Static `T_local_95pct` and `T_local_std` per location per date | Preload once | Low — static dataset |
+| CDC Environmental Public Health Tracking HeatRisk layer | Cross-validates against NOAA | Real-time | Low — external confirmation signal |
+
+Recommended path for v1 Phase 1:
+
+1. Preload NCEI climate normals for every pilot parcel at onboarding. This gives `T_local_95pct(date, location)` without an online dependency.
+2. When NWS HeatRisk data is available for the forecast window, compute `heat_divergence_forecast` against it; do not add to $P_{\text{heat}}$.
+3. Defer programmatic HeatRisk category pull until v1.0 acceptance proves NCEI normals alone are adequate as the local reference.
+
+### Fallback when HeatRisk or NCEI normals unavailable
+
+Use the device's own 10-day rolling 95th percentile of daily max temperature as a degraded local reference. Mark confidence reduced and emit reason "local climatology fallback — NCEI normals unavailable for this parcel."
+
+### Sources
+
+- [NWS HeatRisk overview](https://www.wpc.ncep.noaa.gov/heatrisk/overview.html) — methodology, percentile basis, daily min/max use, CDC integration
+- [NWS HeatRisk home](https://www.wpc.ncep.noaa.gov/heatrisk/) — interactive product and scale
+- [NOAA HeatRisk expansion announcement](https://www.noaa.gov/news-release/noaa-expands-availability-of-new-heat-forecast-tool-ahead-of-summer) — national rollout context
+- [CDC HeatRisk integration](https://ephtracking.cdc.gov/Applications/HeatRisk/) — cross-validation surface
+
+## Section 5 — Deliverables, ready-to-start
+
+Ordered by leverage per unit of effort:
+
+1. **Calibration dataset schema adopted** — §1 as the storage contract; existing logs migrated or a shim view built to produce records in this format.
+2. **Run the readiness checklist** (§2) against existing logs; publish the report in the calibration dataset manifest. This alone may reveal that fits need to wait for better label sources.
+3. **Rolling-baseline replay harness** built in `oesis-runtime/research/rolling_baseline/`. Run against current bench-air traces and existing labels. Report PR + Brier vs v0.
+4. **Preload NCEI climate normals** for pilot parcels. This is a data-ingest job, not a modeling job; can run in parallel with any of the above.
+5. **Only after 1-4**: begin coefficient fitting for the v1 log-odds form, per §4 of `hazard-formula-v1.md`.
+
+## Non-goals for Phase 1
+
+- Implementing the v1 inference path in `v1_1/`. That is Phase 2, gated by the replay results.
+- Modifying `hazard_thresholds_v0.json` or `parcel_prior_rules_v0.json`. v0 stays stable during v1 shadow.
+- Fitting occupant-vulnerability or HVAC-presence coefficients — both deferred in `hazard-formula-v1.md`.
+- Flood work of any kind. Blocked on flood-node hardware.
+
+## Related files
+
+- `hazard-formula-v1.md` — full v1 formula spec
+- `hazard-logic-v0.md` — v0 posture, still authoritative for flood
+- `config/hazard_thresholds_v0.json` — v0 values v1 will eventually replace for smoke and heat
+- `../../release/v.0.1/v0.1-gap-register.md` — G11 tracks this rollout
+- `../../architecture/current/milestone-roadmap.md` — Milestone 2 scope includes the formula adoption

--- a/software/inference-engine/hazard-formula-v1.md
+++ b/software/inference-engine/hazard-formula-v1.md
@@ -1,0 +1,254 @@
+# Hazard Formula v1
+
+## Purpose
+
+Replace the v0 additive-band heuristic with an evidence-based, sensor-primary, log-odds formulation for smoke and heat hazards. Establish provenance, calibration, and divergence-reporting requirements so every number in the production config is traceable to a source and every prediction can be validated against pilot data.
+
+## Status
+
+Draft — supersedes the band logic in `hazard-logic-v0.md` for smoke and heat once adopted. Flood remains on v0 posture until a flood-node exists.
+
+**Revisions:**
+- 2026-04-19 — Heat sensor term corrected. Initial draft treated `T_ref` as a fixed HeatRisk category-1 onset temperature per climate zone; NWS HeatRisk methodology is percentile-based per grid cell and per date, and uses both daily max and daily min. Section "Heat: S_heat(t)" rewritten accordingly. See `hazard-formula-v1-phase1.md` §4 for access-path detail and sources.
+
+## Owner
+
+Open Environmental Sensing and Inference System
+
+## Scope
+
+In scope:
+
+- smoke hazard, evidence from `bench-air-node` (gas resistance) and `mast-lite` / `weather-pm-mast` (PM2.5) when available
+- heat hazard, evidence from `mast-lite` outdoor temperature (primary) and `bench-air-node` indoor temperature (bridge path only)
+- parcel context priors with cited sources
+- contrast/divergence reporting against public and shared sources
+- calibration posture and validation requirements
+
+Out of scope for v1:
+
+- flood hazard (deferred until flood-node hardware ships)
+- occupant vulnerability weighting (requires sourced framework; see `deferred_work`)
+- model training beyond logistic/isotonic fits against pilot labels
+- neighborhood aggregation beyond divergence signal
+
+## Governing commitments
+
+These are the architectural constraints v1 must preserve. They are stronger than v0.
+
+1. **Sensor is the primary source of truth.** The dominant term in every hazard probability is the local sensor evidence. Research-derived thresholds and public feeds do not add to the probability; they calibrate its coefficients and flag divergence.
+2. **Every number cites a source.** Any threshold, coefficient, or multiplier without provenance is marked `expert_elicitation_placeholder` and visible in output.
+3. **Formula is probabilistically coherent.** Log-odds form, coefficients with confidence intervals, outputs calibratable against Brier score and ECE. No post-hoc clamping as a substitute for calibration.
+4. **Divergence is a first-class output.** Disagreement between local sensor and regional/public/shared context is reported alongside the probability, not silently folded into it.
+5. **Prefer `unknown` when evidence is weak.** Unchanged from v0.
+
+## Formula
+
+For hazard $h \in \{\text{smoke}, \text{heat}\}$ at parcel $p$ at time $t$:
+
+$$\text{logit}(P_h) = \alpha_h + \beta_h \cdot S_h(t) + \sum_{i} \gamma_{h,i} \cdot \pi_{h,i}(p) + \delta_h \cdot H(t)$$
+
+where
+
+- $\alpha_h$ is the base log-odds for hazard $h$, calibrated to pilot base rate.
+- $S_h(t)$ is the **sensor evidence term**, defined per hazard below. Standardized so $\beta_h$ is comparable across devices.
+- $\beta_h$ is the sensor coefficient. Required to exceed the sum of absolute prior coefficients by a configured margin — the numerical expression of the sensor-primacy commitment.
+- $\pi_{h,i}(p)$ are parcel priors (construction, defensible space, distance to wildland, etc.), encoded as numeric features with documented scales.
+- $\gamma_{h,i}$ are prior coefficients, each with its own source citation.
+- $H(t)$ is a sensor-health feature (read failures, baseline-stability flag). $\delta_h$ is small and negative — degraded health reduces the magnitude of the sensor's evidentiary push, it does not invert it.
+
+$P_h$ is then obtained via the logistic function and clipped only to $[10^{-4}, 1 - 10^{-4}]$ for numerical stability.
+
+### Status mapping
+
+Unchanged conceptually from v0 — thresholds convert $P_h$ into `unknown` / `safe` / `caution` / `unsafe`. Thresholds are re-derived from pilot reliability curves, not reused from v0. Confidence floors for `shelter_status`, `egress_status`, and `asset_risk_status` are retained; the confidence score itself becomes a function of sensor-health, observation age, divergence magnitude, and presence of prior context.
+
+## Sensor evidence terms
+
+### Smoke: $S_{\text{smoke}}(t)$
+
+Two sensor inputs, additively combined inside $S_{\text{smoke}}$:
+
+1. **Gas resistance deviation** (bench-air-node, always available):
+   - Maintain a rolling per-device baseline of gas resistance over a window $W_{\text{base}}$ (initial target: 48 hours, configurable).
+   - Baseline excludes the most recent $W_{\text{exclude}}$ (initial target: 30 minutes) to avoid absorbing active events into the reference.
+   - Baseline is the rolling median; dispersion is the rolling MAD (median absolute deviation), converted to a robust $\sigma$ estimate.
+   - Signal term: $z_{\text{gas}}(t) = -(R(t) - \text{median}_W) / (1.4826 \cdot \text{MAD}_W)$. Negated so positive values indicate gas-resistance drops (consistent with VOC/smoke loading).
+   - Saturates at $z_{\text{gas}} \in [-3, +8]$ to bound the term.
+
+2. **PM2.5 evidence** (mast-lite / weather-pm-mast, when deployed):
+   - Use $\log_{10}(\max(1, \text{PM}_{2.5}))$ rather than raw ug/m³ — matches EPA AQI's nonlinear health response and avoids the v0 bands discretizing a continuous signal.
+   - When PM2.5 is absent, its contribution to $S_{\text{smoke}}$ is zero, and the confidence score is reduced accordingly. **PM2.5 presence does not shift the probability up; PM2.5 absence makes the estimate less confident, not lower.**
+
+Device-relative baseline replaces the fixed ohm cutoffs in `hazard_thresholds_v0.json:3-17`. This is the single highest-priority accuracy change in v1.
+
+### Heat: $S_{\text{heat}}(t)$
+
+**Correction to initial draft (2026-04-19):** The original draft of this section described $T_{\text{ref}}$ as "the NWS HeatRisk category-1 onset temperature for the parcel's climate zone." Research against the NWS HeatRisk methodology revealed this framing is wrong in two ways that would have encoded into coefficients if not caught:
+
+1. HeatRisk thresholds are **not fixed per climate zone**. They are the warmest 5 % of historical temperatures for each specific grid cell AND each specific date. A February threshold in coastal California is materially lower than its August threshold — same location, different date.
+2. HeatRisk evaluates **both daily max AND daily min**. Hot nights carry independent health risk; a single `T_outdoor(t)` term loses that dimension.
+
+The corrected term below treats local climatology as per-parcel, per-date, with separate day and night components. See `hazard-formula-v1-phase1.md` §4 for access paths and the HeatRisk source citations.
+
+Preferred path — **mast-lite outdoor temperature**, combined day/night z-score against local climatology:
+
+- Day term: $S_{\text{heat,day}}(t) = (T_{\text{max,today}} - T_{\text{local,95}}(\text{date, location})) / T_{\text{local,std}}(\text{date, location})$
+- Night term: $S_{\text{heat,night}}(t) = (T_{\text{min,overnight}} - T_{\text{local,95,min}}(\text{date, location})) / T_{\text{local,std,min}}(\text{date, location})$
+- Combined: $S_{\text{heat}}(t) = \max(S_{\text{heat,day}}(t), \kappa \cdot S_{\text{heat,night}}(t))$ with $\kappa \in (0, 1)$ calibrated against pilot labels.
+- Saturates at $S_{\text{heat}} \in [-3, +8]$ consistent with the smoke term bounds.
+
+Local climatology source: NOAA NCEI 30-year daily Climate Normals, preloaded per pilot parcel at onboarding. When NCEI normals are unavailable for a parcel's exact grid cell, fall back to the device's own 10-day rolling 95th percentile of daily max (and separately of daily min) temperature, with an emitted reason string flagging the fallback and a confidence reduction.
+
+Humidity correction: optionally use heat index or WBGT approximation when humidity data is reliable. Default to dry-bulb with a documented accuracy note until humidity sensor calibration is verified.
+
+Bridge path — **bench-air indoor temperature only**:
+- Retained for pre-mast-lite deployments but with explicit discount: $\beta_{\text{heat,indoor}} \le 0.4 \cdot \beta_{\text{heat,outdoor}}$.
+- Day and night decomposition still applies where data allows, using indoor rolling percentiles per device as the reference if NCEI normals cannot be meaningfully applied to an indoor reading.
+- The indoor-penalty concept from `hazard_thresholds_v0.json:68` is preserved in spirit but implemented as a coefficient reduction, not a subtraction from probability.
+- Estimates derived solely from indoor readings carry a mandatory reason string: "Parcel-wide outdoor heat not sensor-confirmed; estimate bridges from indoor reading."
+
+## Parcel priors ($\pi$)
+
+### Smoke priors (retain from v0 with re-sourcing)
+
+| Feature | v0 source location | v1 source target |
+|---|---|---|
+| `zone_zero_clearance_class` | `parcel_prior_rules_v0.json:6` | NFPA 1144; Cal Fire Zone 0 guidance |
+| `defensible_space_class` | `parcel_prior_rules_v0.json:7` | NFPA 1144; IBHS Suburban Wildfire Adaptation |
+| `roof_class` | `parcel_prior_rules_v0.json:8` | IBHS post-fire structure surveys; ASTM E108 class A |
+| `exterior_class` | `parcel_prior_rules_v0.json:9` | IBHS; NIST TN 1910 |
+| `vent_class` | `parcel_prior_rules_v0.json:10` | CBC Chapter 7A §706A; WUI vent ember research |
+| `window_class` | `parcel_prior_rules_v0.json:11` | IBHS; ASTM E2010 |
+| `distance_to_wildland_ft` | `parcel_prior_rules_v0.json:12` | NIST TN 1910 ember-cast findings; Cal Fire post-event reports |
+
+The distance-to-wildland bands in particular likely need to extend farther than 1500 ft. Post-event analysis of recent WUI fires (Camp, Tubbs, Marshall) documents structure ignition >1 mile from active flame. v1 should widen the band set and re-fit multipliers against pilot data where available.
+
+### Heat priors
+
+| Feature | v0 source location | v1 status |
+|---|---|---|
+| `heat_retention_class` | `parcel_prior_rules_v0.json:2` | Retain; source against ASHRAE 55 and building-envelope thermal mass literature |
+| HVAC capability | not in v0 | **New** — presence, cooling capacity, current operational state. Sourced from parcel context if available; flag as missing otherwise |
+| Occupant vulnerability | not in v0 | **Deferred** — requires sourced framework (CDC Heat Vulnerability Index is a candidate). Until agreed, not a coefficient |
+
+## Health and divergence terms
+
+### Sensor health $H(t)$
+
+Three features, all negative-only so they can reduce sensor weight but never flip its direction:
+
+- `read_failures_recent` — count of failed reads in last hour.
+- `baseline_unstable` — boolean flag when rolling baseline variance exceeds a configured ceiling (sensor not yet conditioned or recovering from contamination).
+- `observation_age_min` — minutes since last reading.
+
+### Divergence channels (reported, not summed into $P_h$)
+
+| Channel | Computation | Emitted as |
+|---|---|---|
+| `smoke_divergence_aqi` | $z_{\text{local smoke}} - z_{\text{regional AQI smoke}}$, normalized to $[-1, +1]$ | sidecar on parcel-state output |
+| `smoke_divergence_neighborhood` | local vs. shared neighborhood smoke index | sidecar |
+| `heat_divergence_forecast` | mast-lite temp vs. NWS forecast temp for same window | sidecar |
+| `heat_divergence_neighborhood` | local vs. shared heat index | sidecar |
+
+Divergence consumers:
+- Large positive divergence with confident local sensor → user-visible reason ("local sensor detected conditions regional sources have not").
+- Large negative divergence with confident regional source → trust gate may suppress `unsafe` escalation and surface "regional context disagrees with local reading" reason.
+
+Divergence **does not change $P_h$.** It changes confidence, trust gates, and emitted reasons only.
+
+## Provenance schema
+
+Every numeric entry in the production hazard config must carry the following structure. Entries without provenance are rejected by the validation harness.
+
+```json
+{
+  "value": <number>,
+  "source": "<citation string or dataset handle>",
+  "source_type": "peer_reviewed | agency_data | insurance_actuarial | internal_empirical | expert_elicitation_placeholder",
+  "date": "<YYYY-MM>",
+  "note": "<one-sentence context>",
+  "n_events": <optional integer, required for internal_empirical>,
+  "ci_95": <optional [low, high], required for internal_empirical>
+}
+```
+
+### Example: smoke base rate and gas-resistance coefficient
+
+```json
+{
+  "smoke": {
+    "formula_version": "v1_logit",
+    "alpha": {
+      "value": -2.8,
+      "source": "pilot_incident_log_2025H2",
+      "source_type": "internal_empirical",
+      "date": "2026-03",
+      "n_events": 42,
+      "note": "Base log-odds of labeled smoke-at-parcel events across pilot fleet."
+    },
+    "beta_gas": {
+      "value": 1.2,
+      "source": "pilot_logistic_fit_2026Q1",
+      "source_type": "internal_empirical",
+      "date": "2026-03",
+      "n_events": 42,
+      "ci_95": [0.7, 1.8],
+      "note": "Log-odds change per +1 standardized unit of gas-resistance deviation from rolling baseline."
+    },
+    "gamma_roof_class_a": {
+      "value": -0.4,
+      "source": "IBHS 2022 Suburban Wildfire Adaptation Roadmap",
+      "source_type": "peer_reviewed",
+      "date": "2022-09",
+      "note": "Class-A roof reduces ember ignition probability; log-odds reduction calibrated to IBHS ember-bed results."
+    }
+  }
+}
+```
+
+## Calibration and validation
+
+### Minimum bar for production adoption
+
+1. **Per-hazard calibration dataset.** Pilot sensor traces paired with labeled hazard outcomes. Each record: `parcel_id`, `window_start`, `window_end`, `hazard`, `label` (∈ {present, absent, uncertain}), `label_source`, `label_date`.
+2. **Reliability curve** per hazard, plotted at deployment time and persisted as an artifact beside the config version.
+3. **Brier score** and **ECE** reported per hazard; v1 adoption requires both to be better than v0 replayed on the same dataset.
+4. **Minimum sample sizes** for any coefficient fitted from pilot data:
+   - $\ge 10$ positive events per coefficient, or
+   - coefficient stays literature-prior with citation.
+5. **CI regression gate** — future config changes must re-run the calibration replay and fail if Brier or ECE regresses beyond a configured tolerance.
+
+### Pilot-log readiness checklist
+
+Before fitting any v1 coefficient from pilot data, confirm:
+
+- [ ] Labels are outcomes, not prior predictions (no circular training).
+- [ ] Label timestamps are the event window, not the alert window.
+- [ ] Parcel context is snapshotted at the event time, not backfilled from current state.
+- [ ] Sensor traces include baseline windows preceding each event (needed for the gas-resistance deviation term).
+- [ ] Negative-class sampling is documented (random windows, matched parcels, or stratified).
+
+## Transition plan from v0
+
+1. **Ship v1 in shadow mode.** The v0 engine remains the source of user-visible state; v1 runs in parallel and logs its probabilities and divergence channels to a versioned sink.
+2. **Accumulate two-week shadow log** across the pilot fleet, replay pilot incident labels, report Brier/ECE for both v0 and v1.
+3. **Promote v1 per hazard independently.** Smoke and heat can flip to v1 at different times if one hazard's calibration matures first.
+4. **Deprecate v0 bands** only after v1 has been primary for a defined stabilization window.
+5. **Retain `hazard-logic-v0.md`** for flood logic until the flood-node lands and a v1 flood spec is written.
+
+## Deferred work
+
+- Occupant vulnerability coefficient (needs sourced framework).
+- PM2.5-only smoke estimates (requires mast-lite or weather-pm-mast at parcel).
+- Cross-parcel Bayesian pooling for sparse deployments.
+- Automatic detection of sensor conditioning drift (beyond the `baseline_unstable` flag).
+- Flood formula v1 (blocked on hardware).
+
+## Related files
+
+- `hazard-logic-v0.md` — v0 posture, still authoritative for flood.
+- `config/hazard_thresholds_v0.json` — values v1 replaces for smoke and heat.
+- `config/trust_gates_v0.json` — retained; divergence channels feed into it.
+- `oesis-runtime/oesis/inference/v1_0/parcel_first_hazard.py` — current implementation site; v1 implementation should live in a `v1_1/` sibling to avoid disrupting the v0 path during shadow evaluation.
+- `oesis-runtime/oesis/assets/v0.5/config/inference/parcel_prior_rules_v0.json` — prior multipliers v1 re-sources and converts from multiplicative to log-odds contributions.

--- a/software/ingest-service/architecture.md
+++ b/software/ingest-service/architecture.md
@@ -59,6 +59,14 @@ event publication for:
 - HVAC / purifier / recirculation / similar equipment state
 - action and verification records tied to later response windows
 
+### Planned: admissibility decision on each normalized observation
+
+Per ADR [0009](../../meta/adr/0009-admissibility-schema-split-facts-vs-decision.md) and [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §C, the ingest service is the canonical place that computes the **admissibility decision** on each normalized observation. Schema carries the facts (`burn_in_complete`, `node_calibration_session_ref`, `node_deployment_maturity`, `node_deployment_class`, `protective_fixture_verified_at`, `placement_representativeness_class` for physical sensors; plus adapter-derived equivalents for Tier 1 / Tier 2 observations). Runtime attaches `admissible_to_calibration_dataset: bool` plus `admissibility_reasons: [string]` to each normalized observation.
+
+Branch rule: observations with `adapter_tier` absent or `tier_3_direct` are evaluated against calibration-program §C (8 checks). Observations with `adapter_tier: tier_1_passive` or `tier_2_adapter` are evaluated against [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §C with adapter-specific reason codes.
+
+Status: **planned**. Schema extensions tracked as G17; runtime wiring tracked as G15. Until shipped, ingest emits observations without the admissibility decision and downstream consumers treat all normalized readings as "admissibility unknown."
+
 ## Internal modules
 
 - transport adapter

--- a/software/parcel-platform/architecture.md
+++ b/software/parcel-platform/architecture.md
@@ -37,6 +37,16 @@ It is also the primary surface for showing sharing choices, consent state, and p
 - export/delete/revocation request entry points
 - future alerts or notification candidates
 
+### Planned: admissibility state in evidence surface
+
+Per ADR [0009](../../meta/adr/0009-admissibility-schema-split-facts-vs-decision.md) and gap register G24, the evidence summary and explanation payload will eventually surface the admissibility state of the observations that fed a parcel-state claim:
+
+- Per-observation: the `admissibility_reasons` list passed through from ingest (e.g., `burn_in_incomplete`, `reference_calibration_stale`, `fixture_unverified`, `contract_version_drift`).
+- Per-parcel summary: admissibility rate across the observation window; calibration-posture badge indicating whether contributing nodes meet `deployment maturity v1.0` per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §G.
+- Reason strings from a controlled vocabulary when confidence is degraded because of calibration state (distinct from confidence degradation caused by freshness, health, or placement).
+
+Status: **planned**. Waits for the v1.5 evidence-view product surface. Parcel-state itself consumes admissibility in inference (see [`../inference-engine/architecture.md`](../inference-engine/architecture.md)); exposing it in the platform's dwelling-facing surface is a later step so that language can be reviewed before admissibility jargon reaches end users.
+
 ## Internal modules
 
 - parcel-state reader

--- a/software/shared-map/architecture.md
+++ b/software/shared-map/architecture.md
@@ -22,6 +22,14 @@ core current-v1 product behavior.
 - public context layers suitable for map display
 - map publication policy constraints
 
+### Planned: admissibility gate on shared-layer eligibility
+
+Per gap register G22 and the shared-layer eligibility rule in [`../../architecture/system/sensor-placement-and-representativeness-guide.md`](../../architecture/system/sensor-placement-and-representativeness-guide.md) "Product behavior implications", shared-layer contribution requires the contributing node's most recent observation to be admissible per [`../../architecture/system/calibration-program.md`](../../architecture/system/calibration-program.md) §C (physical sensors) or [`../../architecture/system/adapter-trust-program.md`](../../architecture/system/adapter-trust-program.md) §C (adapter-derived).
+
+Concrete consequence: a well-placed but uncalibrated node (for example, a bench-air node without a populated reference instrument, G13) cannot contribute to shared-map aggregation even if it has an active sharing setting. The gate runs **after** sharing-policy check and **before** the thresholding / coarsening modules.
+
+Status: **planned**. Ships as part of the v0.5 governance slice or later. Until wired, the current aggregation-and-thresholding module treats all opted-in contributions as eligible — which over-counts during the v0.1 / v0.2 period where admissibility tooling itself (G15) is not yet active.
+
 ## Outputs
 
 - coarse shared neighborhood condition view


### PR DESCRIPTION
Introduces the calibration-program and adapter-trust-program as the platform policy surfaces governing every node family's deployment posture, reference instruments, burn-in, admissibility, and drift. Adds per-node aggregator pages so consistency across repos is verifiable in one place. Extends master architecture docs, version-control docs, gap register, and release surfaces so every canonical reader sees the new layer.

New canonical docs (architecture/system/):
- calibration-program.md — reference instruments §A, burn-in §B, admissibility rule §C, drift policy §D, session log §E, build-spec metadata §F, promotion-bar compliance §G
- adapter-trust-program.md — parallel program for Tier 1 passive and Tier 2 cloud-API adapter-derived data, same output shape
- architectural-choices-by-stage.md — master table of class/power/IP/ transport/calibration/adapter tier across program phases
- parts/ — 6 per-node aggregator pages (bench-air, mast-lite, flood, weather-pm-mast, thermal-pod, circuit-monitor) that cite upstream canonical sources; 9-place-scatter becomes one-page lookup

New policy docs (meta/):
- doc-discipline.md — five rules slowing doc proliferation (extend before creating, summaries cite don't duplicate, canonical-home declaration, per-version directories require intent, redirects self-identify)
- 5 ADRs (0007-0011): hazard-formula-v1 sensor-primary log-odds, mast-lite option A, admissibility schema/runtime split, adapter-trust parallel program, doc-discipline
- 2 build-vault proposals: calibration-program integration + node skeletons

Hazard formula v1 (software/inference-engine/):
- hazard-formula-v1.md — log-odds form replacing v0 additive bands; sensor as main source of truth with beta_sensor > sum|gamma|; per-device rolling baseline for gas resistance; NWS HeatRisk per-parcel/per-date normals for heat (correction to initial draft); provenance schema on every coefficient
- hazard-formula-v1-phase1.md — Phase-0 hardware prerequisites; calibration dataset schema; pilot-log readiness checklist; rolling- baseline replay harness spec

Platform-standard extensions (architecture/system/):
- deployment-maturity-ladder.md — power/IP/transport tier per deployment class (indoor/sheltered/outdoor)
- sensor-placement-and-representativeness-guide.md — placement-to-class map and sensor variant selection principles
- node-taxonomy.md — per-family posture tags; circuit-monitor as Tier 3 adapter
- integrated-parcel-system-spec.md — deployment posture per node table
- cross-repo-architecture.md — calibration/admissibility cross-repo flow
- technical-philosophy-and-architecture.md — principle 9 (admissibility is an evidence-layer fact, not an inference side-effect)
- phase-roadmap.md — per-stage deployment posture for Stages A-F
- version-and-promotion-matrix.md — calibration-program cited in axes
- architecture-gaps-by-stage.md — calibration program placed at current v1

Version-control updates (architecture/current/):
- pre-1.0-version-progression.md — new 5th promotion-bar item requiring calibration-program compliance at target deployment-maturity tier; retroactivity rule (forward-only; v0.1 sign-off not reopened)
- milestone-roadmap.md — Milestone 2 now requires mast-lite spec + calibration + shield design; both bench-air AND mast-lite at deployment-maturity v1.0 per promotion bar
- v1.0-parcel-kit-architecture.md — deployment-maturity requirements explicit; calibration-program §G compliance bar cited
- v0.1-acceptance-criteria.md — deployment posture subsection
- v0.1-boundary-and-non-goals.md — forward-looking non-goal rows
- architecture-object-map.md — 3 new first-class objects (calibration session, admissibility fact, adapter source authority)
- component-boundaries.md — calibration and adapter-trust cited
- implementation-posture.md — planned/docs-only status per component
- reference-stack.md — admissibility decision as first-class ingest output

v1.5 surface alignment (architecture/v1.5/):
- house-state-and-verification-model.md — posture per surface including Tier 1/2/3 adapter tiers
- README.md — "why this lane is thin" pointer map to system/

OSI diagrams (release/v.0.1/):
- Figure 8 — LoRa transport (v0.3+ flood-node and outdoor nodes beyond Wi-Fi reach)
- Figure 9 — Cellular transport (outdoor beyond Wi-Fi)
- Figure 10 — Direct-measurement adapter chained transport (circuit- monitor Modbus + Wi-Fi)
- Figure 11 — Radiation-shield hardware component (hardware-only figure since shield is pure L1 with admissibility consequences)
- Figures 1, 4, 5 — new "Deployment posture" annotations citing §F blocks and deployment-maturity-ladder

Gap register (release/v.0.1/v0.1-gap-register.md):
- 14 new entries G11-G24 covering formula rewrite, missing build specs, reference instruments, burn-in gates, admissibility tooling, schema facts, adapter-trust execution, pilot gates, bring-up enforcement, CI validation, shared-layer gating, config provenance, product evidence
- Pivot views: by promotion bar, by affected node family, by owner, dependency chain, status buckets

Release docs (release/v1.0/):
- v1.0-scope.md — "Deployment maturity at v1.0" block naming §A-§G compliance bar
- v1.0-scope-matrix.md — calibration-program posture table with 6 rows
- v1.0-launch-checklist.md — 5 new hardware-readiness gates HR-7 through HR-11
- v1.0-pilot-minimum-subset.md — 5 new Tier B stop-ship gates

Downstream (operations, legal, program):
- operations/pilots/first-block-pilot.md — calibration-program compliance as 5-item pre-enrollment checklist (G19)
- legal/README.md — redirect + reader-question signpost
- program/operating-packet/09-phasing-v0.1-v1.0-v1.5.md — per-phase deployment posture blocks

Subsystem architecture docs (software/):
- ingest-service/architecture.md — planned admissibility emission
- inference-engine/architecture.md — planned admissibility filter + adapter-tier branching
- parcel-platform/architecture.md — planned admissibility state in evidence surface (v1.5 product surface)
- shared-map/architecture.md — planned calibration gate on shared-layer eligibility (G22)

Repo navigation:
- README.md — "Navigating this repo" section with top-level directory map + reading paths by goal
- meta/repo-manifest.md — all new canonical docs registered

All edits additive per doc-discipline rule 1; summary docs cite canonical sources per rule 2; redirect docs self-identify per rule 5.

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Asset class

<!-- Which license applies to the files you changed? Check one. -->

- [ ] Documentation / specifications (CC BY-SA 4.0)
- [ ] Software in `software/` (GNU AGPL v3)
- [ ] Hardware in `hardware/` (CERN-OHL-S-2.0)

## Checklist

- [ ] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [ ] I have read [`NOTICE.md`](../NOTICE.md) and understand the release posture
- [ ] My changes do not include real participant data or credentials
- [ ] My changes are consistent with the sibling repos (runtime / public-site) where applicable
- [ ] I have updated or added relevant documentation for my changes

## Test plan

<!-- How can reviewers verify this change? Link to make targets, manual steps, or example commands. -->
