### PR TITLE
docs(meta): close out version-first matrix as complete-as-done

### DIFF
--- a/meta/directory-versioning-destination-matrix.md
+++ b/meta/directory-versioning-destination-matrix.md
@@ -1,34 +1,45 @@
 # Directory versioning destination matrix
 
-This matrix defines canonical destinations for the directory-versioning rollout.
-Legacy root paths remain as compatibility stubs.
+This matrix is the historical record of the directory-versioning rollout. It documents where each top-level subtree landed, why, and whether further work is expected.
+
+The rollout is **complete at its planned scope**. No further subtrees are being moved to version-first canonical layout (see "Status" column below).
 
 ## Conventions
 
 - **Baseline lane**: `v0.1/`
 - **Additive lanes**: `v1.0/`, `v1.5/`
-- **Compatibility**: old path becomes a redirect stub
+- **Two distinct patterns observed**:
+  - **`v0.1/` canonical** — canonical content lives under `v0.1/`; later lanes inherit or add (used by oesis-contracts and oesis-hardware sibling repos)
+  - **`v0.1/` lane-contract** — canonical content stays at its natural location (e.g., `meta/adr/`, `software/inference-engine/`); `v0.1/README.md` is a thin lane-contract doc that explains the versioning posture for that subtree (used by program-specs subtrees)
 
 ## Top-level directory mapping
 
-| Directory | Current canonical path | Canonical destination | Legacy path action |
+| Directory | Pattern | Status | Notes |
 | --- | --- | --- | --- |
-| `contracts/` | [`README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/README.md) | [`v0.1/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/README.md) | keep [`README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/README.md) as redirect |
-| `contracts/` schemas index | [`v0.1/schemas/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/schemas/README.md) | [`v0.1/schemas/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/schemas/README.md) | legacy root stub deleted (2026-04-23) |
-| `contracts/` examples index | [`v0.1/examples/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/examples/README.md) | [`v0.1/examples/README.md`](https://github.com/lumenaut-llc/oesis-contracts/blob/main/v0.1/examples/README.md) | legacy root stub deleted (2026-04-23) |
-| `artifacts/` | `artifacts/README.md` | `artifacts/v0.1/README.md` | keep `artifacts/README.md` as redirect |
-| `release/` | `release/README.md` | `release/v0.1/README.md` (lane contract) | keep `release/README.md` as redirect |
-| `software/` | `software/README.md` | `software/v0.1/README.md` | keep `software/README.md` as redirect |
-| `hardware/` | `hardware/README.md` | `hardware/v0.1/README.md` | keep `hardware/README.md` as redirect |
-| `operations/` | `operations/README.md` | `operations/v0.1/README.md` | keep `operations/README.md` as redirect |
-| `legal/` | `legal/README.md` | `legal/v0.1/README.md` | keep `legal/README.md` as redirect |
-| `media/` | `media/README.md` | `media/v0.1/README.md` | keep `media/README.md` as redirect |
-| `program/` | `program/README.md` | `program/v0.1/README.md` | keep `program/README.md` as redirect |
-| `meta/` | `meta/README.md` | `meta/v0.1/README.md` | keep `meta/README.md` as redirect |
+| `contracts/` (sibling repo `oesis-contracts`) | `v0.1/` canonical | ✅ canonical complete | Root stubs (`schemas/`, `examples/`) deleted 2026-04-23 |
+| `hardware/` (sibling repo `oesis-hardware`) | `v0.1/` canonical | ✅ canonical complete | Restructure landed 2026-04-23 (PR #8); families and parcel-kit/calibration moved into `v0.1/`; `circuit-monitor` to `v1.5/` |
+| `release/` | `v0.1/` canonical | ✅ canonical complete | Was already version-first (release packets are inherently per-slice) |
+| `artifacts/` | `v0.1/` lane-contract | ✅ lane-contract in place | `artifacts/v0.1/README.md` documents lane posture; canonical bundles stay at `artifacts/contracts-bundle/` etc. |
+| `software/` | `v0.1/` lane-contract | ✅ lane-contract in place | Per-subsystem stubs in `v0.1/<subsystem>/README.md` redirect to canonical `software/<subsystem>/` |
+| `operations/` | `v0.1/` lane-contract | ✅ lane-contract in place | `operations/v0.1/README.md` documents lane posture; `pilots/` stays at root |
+| `legal/` | `v0.1/` lane-contract | ✅ lane-contract in place | `legal/v0.1/README.md` documents lane posture; per-topic dirs (`privacy/`, etc.) stay at root |
+| `meta/` | `v0.1/` lane-contract | ✅ lane-contract in place | `meta/v0.1/README.md` documents lane posture; cross-version artifacts (`adr/`, `milestones/`, `proposals/`) stay at root |
+| `program/` | `v0.1/` lane-contract | ✅ lane-contract in place | `program/v0.1/README.md` documents lane posture; `operating-packet/` stays at root |
 
-## Explicit exclusions (this pass)
+## Why two patterns
 
-- Do not move release packet files or subsystem-specific deep content trees in
-  this pass.
-- This rollout prioritizes canonical lane contracts and contract baseline
-  docs/assets first, then updates references repo-wide.
+The `v0.1/` canonical pattern (used in contracts and hardware) fits content with **clear per-version product evolution** — schema versions, hardware revisions. Moving the canonical content under `v0.1/` and treating later lanes as deltas/redirects works because the content has a meaningful per-version semantic.
+
+The `v0.1/` lane-contract pattern (used in program-specs subtrees) fits content that is **mostly cross-version** — ADRs, system architecture programs, proposals, current-state docs, legal posture. Forcing this content under `v0.1/` would falsely imply it's version-scoped. The lane-contract stub gives the subtree a documented versioning posture without restructuring its semantics.
+
+## Explicit non-rollouts
+
+- **No further subtrees** in oesis-program-specs are being moved to `v0.1/` canonical. The lane-contract stubs are the endpoint, not a stepping stone.
+- **`media/`** was listed in earlier drafts but the directory does not exist; row removed.
+- **Subsystem-specific deep content trees** (e.g., `architecture/decisions/`, `software/inference-engine/`, `meta/adr/`) are not version-scoped and stay at their natural location — the lane-contract stubs reference them as canonical.
+
+## Related
+
+- [`meta/oesis-build-decision.md`](oesis-build-decision.md) — sibling decision about a different directory structure question
+- [`meta/doc-discipline.md`](doc-discipline.md) — overall doc-organization rules
+- [`meta/repo-split-plan.md`](repo-split-plan.md) — historical context for the contracts/hardware extractions


### PR DESCRIPTION
## Summary

Cleanup of `meta/directory-versioning-destination-matrix.md`. The doc was framed as describing an in-progress "rollout," which became misleading after contracts and hardware landed as v0.1/ canonical and the program-specs subtrees received their lane-contract stubs (all of which has happened).

## What changed

- **Pattern + Status columns** showing each subtree's outcome: `v0.1/` canonical (contracts, hardware, release) vs `v0.1/` lane-contract (artifacts, software, operations, legal, meta, program), all marked complete
- **Document the two patterns** and why each fits its subtree's semantic — per-version product evolution vs cross-version concerns
- **Remove `media/` row** (directory does not exist)
- **Replace "rollout in progress" framing with "historical record"**
- **Add explicit non-rollouts section** noting no further subtrees are being restructured

## What did NOT change

- No directories moved
- No stubs deleted (each `v0.1/README.md` is a substantive 30-147 line lane-contract doc, not noise)

## Why this matters

Future contributors reading the matrix would have assumed there was pending work to extend version-first to the remaining subtrees. There isn't — the lane-contract stubs are the intentional endpoint for those subtrees, and the `v0.1/` canonical pattern (used in contracts and hardware) doesn't fit cross-version content like ADRs, system architecture programs, and legal posture.

## Test plan
- [x] Local markdownlint passes (0 errors)
- [ ] CI checks green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)