### PR TITLE
feat(drift): add builds + wiki coverage to cross_repo_sync_check.py

### DIFF
--- a/architecture/system/cross-repo-architecture.md
+++ b/architecture/system/cross-repo-architecture.md
@@ -130,8 +130,21 @@ full four-axis model.
 |-----------|-------|----------------|
 | `make cross-repo-sync` | specs | Example sync, schema coverage, lane alignment, manifest freshness, hardware URL validation |
 | `cross-repo-sync` CI job | specs GitHub Actions | Same checks on every push/PR |
+| `cross-repo-drift.yml` | specs GitHub Actions | Nightly safety net; opens drift issue when out-of-band edits land |
 | `cross-repo-example-sync` CI job | runtime GitHub Actions | Byte-compares canonical lane examples against specs |
+| `validate_examples.py` | contracts repo | Validates every example against its schema across v0.1, v1.0, v1.5, and the bundle |
 | `version-manifest.json` | specs repo root | Machine-readable snapshot of all 4 repos' alignment state |
+
+### Non-git satellite working dirs
+
+Two ancillary directories live alongside the four canonical repos but are **not git-managed**:
+
+| Working dir | Purpose | Sync posture |
+|---|---|---|
+| `oesis-builds/` | Build vault — per-unit specs, decisions, procedures, calibration logs | Soft-validated by `cross_repo_sync_check.py`'s `check_builds_cross_refs()`. Validates relative paths to sibling repos (e.g., `../../oesis-hardware/<lane>/<family>/`). Soft-skips when not present (CI does not clone). |
+| `oesis-wiki/` | Research notes and concept wiki | Soft-validated by `cross_repo_sync_check.py`'s `check_wiki_cross_refs()`. Validates textual sibling-repo path references resolve to real files. Soft-skips when not present. |
+
+These satellites are best-effort local-only validation surfaces — they catch drift when a maintainer runs `make cross-repo-sync` locally, but do not gate CI. Add them to a future automated lane if they migrate to git.
 
 ## Cross-repo artifact bundles
 

--- a/scripts/cross_repo_sync_check.py
+++ b/scripts/cross_repo_sync_check.py
@@ -26,6 +26,11 @@ CONTRACTS_ROOT = SPECS_ROOT.parent / "oesis-contracts"
 RUNTIME_ROOT = SPECS_ROOT.parent / "oesis-runtime"
 HARDWARE_ROOT = SPECS_ROOT.parent / "oesis-hardware"
 PUBLIC_SITE_ROOT = SPECS_ROOT.parent / "oesis-public-site"
+# Non-git satellite working dirs. Soft-skipped when not present (CI does not
+# clone these — they live as local working dirs maintained outside the
+# release-fanout flow, so coverage here is best-effort local validation).
+BUILDS_ROOT = SPECS_ROOT.parent / "oesis-builds"
+WIKI_ROOT = SPECS_ROOT.parent / "oesis-wiki"
 
 # Lanes where specs owns canonical examples (baseline + additive lanes).
 # Overlay lanes v0.2-v0.5 intentionally have no specs examples — runtime
@@ -347,6 +352,111 @@ def check_hardware_contract_urls() -> list[str]:
     return errors
 
 
+def check_builds_cross_refs() -> list[str]:
+    """Validate relative ../oesis-<repo>/ paths in oesis-builds markdown resolve.
+
+    oesis-builds is a non-git working dir with markdown links to sibling repos
+    via relative paths (e.g., ../../../oesis-hardware/v0.1/bench-air-node/...).
+    Without CI for builds itself, these references can break silently when a
+    sibling repo restructures. Soft-skips when builds is not present locally.
+    """
+    errors: list[str] = []
+    if not check_repo_exists(BUILDS_ROOT, "oesis-builds"):
+        return errors  # soft-skip: builds is not git-cloned in CI today
+
+    import re
+    pattern = re.compile(r"(?:\.\./)+oesis[_-][a-z_-]+/[^\s)\"'\]`#?]+")
+
+    for md_file in BUILDS_ROOT.rglob("*.md"):
+        if ".git" in md_file.parts or "node_modules" in md_file.parts:
+            continue
+        # Skip template files — they intentionally contain placeholder paths
+        # like `../oesis-hardware/<node>/firmware/` for the reader to fill in.
+        if "_template" in md_file.parts or "_templates" in md_file.parts:
+            continue
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError):
+            continue
+
+        for match in pattern.finditer(content):
+            rel = match.group(0).rstrip("/").rstrip(".").rstrip(",")
+            if not rel:
+                continue
+            # Skip template placeholders like <node>, <slug>, or glob patterns
+            # like ../oesis-hardware/** (used in vault-scope documentation, not
+            # as navigable paths).
+            if "<" in rel or ">" in rel or "*" in rel:
+                continue
+
+            target = (md_file.parent / rel).resolve()
+            if not target.exists():
+                try:
+                    rel_md = md_file.relative_to(BUILDS_ROOT)
+                except ValueError:
+                    rel_md = md_file
+                errors.append(
+                    f"oesis-builds/{rel_md}: broken relative path — "
+                    f"'{match.group(0)}' does not resolve"
+                )
+
+    return errors
+
+
+def check_wiki_cross_refs() -> list[str]:
+    """Validate textual oesis-<repo>/<path> references in oesis-wiki markdown.
+
+    oesis-wiki uses prose mentions rather than markdown links (e.g.,
+    backtick-wrapped `oesis-hardware/v0.1/<family>/file.md`). These are logical
+    pointers; they should reference real files relative to the oesis_master
+    parent dir. Restricts matching to references that end in a recognised
+    file extension to avoid noisy false positives on dir-name mentions.
+    Soft-skips when wiki is not present locally.
+    """
+    errors: list[str] = []
+    if not check_repo_exists(WIKI_ROOT, "oesis-wiki"):
+        return errors  # soft-skip
+
+    import re
+    # Only validate refs that end in a recognised file extension
+    pattern = re.compile(
+        r"oesis[_-][a-z_-]+/[a-zA-Z0-9._/-]+\."
+        r"(?:md|json|csv|toml|yaml|yml|h|cpp|py|sh|ino|ts|tsx|js)"
+    )
+
+    for md_file in WIKI_ROOT.rglob("*.md"):
+        if ".git" in md_file.parts or "node_modules" in md_file.parts:
+            continue
+        # Skip template files
+        if "_template" in md_file.parts or "_templates" in md_file.parts:
+            continue
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError):
+            continue
+
+        for match in pattern.finditer(content):
+            rel = match.group(0)
+            if not rel:
+                continue
+            # Skip refs containing template placeholders or globs
+            if "<" in rel or ">" in rel or "*" in rel:
+                continue
+
+            target = WIKI_ROOT.parent / rel
+            if not target.exists():
+                try:
+                    rel_md = md_file.relative_to(WIKI_ROOT)
+                except ValueError:
+                    rel_md = md_file
+                errors.append(
+                    f"oesis-wiki/{rel_md}: broken sibling-repo path — "
+                    f"'{rel}' not found in oesis_master"
+                )
+
+    return errors
+
+
 def check_specs_verified_commit() -> list[str]:
     """Warn if version-manifest's recorded oesis-contracts commit lags HEAD."""
     manifest_path = SPECS_ROOT / "version-manifest.json"
@@ -390,6 +500,8 @@ def main() -> int:
         ("Version manifest", check_version_manifest),
         ("Public-site bundle freshness", check_public_site_bundle_freshness),
         ("Hardware contracts URL validity", check_hardware_contract_urls),
+        ("Builds cross-reference validation (relative paths)", check_builds_cross_refs),
+        ("Wiki cross-reference validation (sibling-repo paths)", check_wiki_cross_refs),
         ("Specs verified-commit freshness", check_specs_verified_commit),
     ]
 


### PR DESCRIPTION
## Summary

Closes #203. Implements the largest-ROI item from the 2026-04-25 multi-repo audit — adds drift detection for the two non-git satellite working dirs (`oesis-builds`, `oesis-wiki`) which previously had **zero monitoring** for cross-repo path drift.

## What changed

**`scripts/cross_repo_sync_check.py`:**

- New `BUILDS_ROOT` and `WIKI_ROOT` constants pointing at the master sibling working dirs
- New `check_builds_cross_refs()` — validates `../oesis-<repo>/` relative paths in builds markdown actually resolve
- New `check_wiki_cross_refs()` — validates `oesis-<repo>/<path>` textual refs in wiki markdown resolve to real files relative to `oesis_master`
- Both wired into the `main()` check list
- Both soft-skip when target dir is absent
- Both filter out template placeholders (`<...>`), glob patterns (`*`), and files in `_template/` dirs

**`architecture/system/cross-repo-architecture.md`:**

- Added "Non-git satellite working dirs" subsection documenting the new coverage and explaining the local-only validation posture

## CI behavior

CI does NOT clone `oesis-builds` or `oesis-wiki` (neither is on GitHub as a clone-able repo). The new checks soft-skip when their target dir is absent, so CI sees no new failures. Verified via local CI simulation (separate working tree without builds/wiki present) — all checks pass.

## Local-run behavior

Anyone running `make cross-repo-sync` from a master working tree with `oesis-builds/` and `oesis-wiki/` present will see the new checks run. They surface 32 pre-existing broken refs that previously went undetected. **These are tracked separately as #205** and should be fixed by sed-applying corrected relative paths to the working dirs (the affected dirs aren't git-managed so the fix can't go through PR review).

## Test plan

- [x] `python3 scripts/cross_repo_sync_check.py` from a CI-like working tree (builds/wiki absent) → passes
- [x] `python3 scripts/cross_repo_sync_check.py` from full master tree → finds 32 real broken refs in builds/wiki (expected; tracked as #205)
- [x] Existing checks unaffected
- [ ] CI green on this PR

## Follow-ups

- #205 — Fix the 32 broken refs in oesis-builds + oesis-wiki (separate ticket; not git-managed so can't go through PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)