### PR TITLE
chore(sync): bump oesis-contracts last_verified_commit

### DIFF
--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.0",
-  "generated_at": "2026-04-24T00:39:08Z",
+  "generated_at": "2026-05-01T21:16:19Z",
   "description": "Cross-repo version alignment manifest for the OESIS project. This file declares the current version state across all five repositories. Validate with: python3 scripts/cross_repo_sync_check.py",
   "repos": {
     "oesis-program-specs": {
@@ -13,7 +13,7 @@
       "url": "https://github.com/lumenaut-llc/oesis-contracts",
       "role": "Canonical schemas, examples, and contract prose",
       "license": "CC BY-SA 4.0 / AGPL-3.0",
-      "last_verified_commit": "4bb10f3fddd4427b3165a88ab7fcb0e31fef414d"
+      "last_verified_commit": "cb08b673a655208723c3d3cc59202b3d5b9f533a"
     },
     "oesis-runtime": {
       "url": "https://github.com/lumenaut-llc/oesis-runtime",


### PR DESCRIPTION
## Summary

Routine bump of \`version-manifest.json\` after G17 (contracts#11) + G18 schema-side (contracts#12) merged.

Generated mechanically by:
\`\`\`
python3 scripts/repo_split.py sync-specs-refs
\`\`\`

## Test plan

- [ ] Cross-repo CI green (this is exactly what cross_repo_sync_check looks for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)